### PR TITLE
feat: add biometrics tracking and simplify home screen navigation

### DIFF
--- a/app/src/main/java/com/foodsymptomlog/MainActivity.kt
+++ b/app/src/main/java/com/foodsymptomlog/MainActivity.kt
@@ -13,10 +13,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.foodsymptomlog.ui.screens.AddBloodPressureScreen
+import com.foodsymptomlog.ui.screens.AddCholesterolScreen
 import com.foodsymptomlog.ui.screens.AddMealScreen
 import com.foodsymptomlog.ui.screens.AddMedicationScreen
 import com.foodsymptomlog.ui.screens.AddOtherEntryScreen
 import com.foodsymptomlog.ui.screens.AddSymptomScreen
+import com.foodsymptomlog.ui.screens.AddWeightScreen
 import com.foodsymptomlog.ui.screens.CalendarScreen
 import com.foodsymptomlog.ui.screens.HistoryScreen
 import com.foodsymptomlog.ui.screens.HomeScreen
@@ -44,38 +47,104 @@ class MainActivity : ComponentActivity() {
                             HomeScreen(
                                 viewModel = viewModel,
                                 onAddMeal = { navController.navigate("add_meal") },
-                                onAddSymptom = { navController.navigate("add_symptom") },
-                                onAddOther = { navController.navigate("add_other") },
-                                onAddMedication = { navController.navigate("add_medication") },
+                                onAddSymptom = { name ->
+                                    if (name != null) navController.navigate("add_symptom?name=$name")
+                                    else navController.navigate("add_symptom")
+                                },
+                                onAddOther = { otherType -> navController.navigate("add_other?type=$otherType") },
+                                onAddMedication = { name ->
+                                    if (name != null) navController.navigate("add_medication?name=$name")
+                                    else navController.navigate("add_medication")
+                                },
+                                onAddBloodPressure = { navController.navigate("add_blood_pressure") },
+                                onAddCholesterol = { navController.navigate("add_cholesterol") },
+                                onAddWeight = { navController.navigate("add_weight") },
                                 onViewHistory = { navController.navigate("history") },
                                 onViewCalendar = { navController.navigate("calendar") },
                                 onViewSettings = { navController.navigate("settings") },
                                 onEditMeal = { id -> navController.navigate("edit_meal/$id") },
                                 onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
                                 onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") }
+                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
+                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
+                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
+                                onEditWeight = { id -> navController.navigate("edit_weight/$id") }
                             )
                         }
-                        composable("add_meal") {
+                        composable(
+                            route = "add_meal?mealType={mealType}",
+                            arguments = listOf(navArgument("mealType") {
+                                type = NavType.StringType
+                                nullable = true
+                                defaultValue = null
+                            })
+                        ) { backStackEntry ->
+                            val mealType = backStackEntry.arguments?.getString("mealType")
                             AddMealScreen(
                                 viewModel = viewModel,
-                                onNavigateBack = { navController.popBackStack() }
+                                onNavigateBack = { navController.popBackStack() },
+                                preselectedMealType = mealType
                             )
                         }
-                        composable("add_symptom") {
+                        composable(
+                            route = "add_symptom?name={name}",
+                            arguments = listOf(navArgument("name") {
+                                type = NavType.StringType
+                                nullable = true
+                                defaultValue = null
+                            })
+                        ) { backStackEntry ->
+                            val prefillName = backStackEntry.arguments?.getString("name")
                             AddSymptomScreen(
                                 viewModel = viewModel,
-                                onNavigateBack = { navController.popBackStack() }
+                                onNavigateBack = { navController.popBackStack() },
+                                prefillName = prefillName
                             )
                         }
-                        composable("add_other") {
+                        composable(
+                            route = "add_other?type={type}",
+                            arguments = listOf(navArgument("type") {
+                                type = NavType.StringType
+                                nullable = true
+                                defaultValue = null
+                            })
+                        ) { backStackEntry ->
+                            val otherType = backStackEntry.arguments?.getString("type")
                             AddOtherEntryScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                preselectedType = otherType
+                            )
+                        }
+                        composable(
+                            route = "add_medication?name={name}",
+                            arguments = listOf(navArgument("name") {
+                                type = NavType.StringType
+                                nullable = true
+                                defaultValue = null
+                            })
+                        ) { backStackEntry ->
+                            val prefillName = backStackEntry.arguments?.getString("name")
+                            AddMedicationScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                prefillName = prefillName
+                            )
+                        }
+                        composable("add_blood_pressure") {
+                            AddBloodPressureScreen(
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() }
                             )
                         }
-                        composable("add_medication") {
-                            AddMedicationScreen(
+                        composable("add_cholesterol") {
+                            AddCholesterolScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() }
+                            )
+                        }
+                        composable("add_weight") {
+                            AddWeightScreen(
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() }
                             )
@@ -93,7 +162,10 @@ class MainActivity : ComponentActivity() {
                                 onEditMeal = { id -> navController.navigate("edit_meal/$id") },
                                 onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
                                 onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") }
+                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
+                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
+                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
+                                onEditWeight = { id -> navController.navigate("edit_weight/$id") }
                             )
                         }
                         composable("history") {
@@ -103,7 +175,10 @@ class MainActivity : ComponentActivity() {
                                 onEditMeal = { id -> navController.navigate("edit_meal/$id") },
                                 onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
                                 onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") }
+                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
+                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
+                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
+                                onEditWeight = { id -> navController.navigate("edit_weight/$id") }
                             )
                         }
                         // Edit routes
@@ -149,6 +224,39 @@ class MainActivity : ComponentActivity() {
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() },
                                 editId = medicationId
+                            )
+                        }
+                        composable(
+                            route = "edit_blood_pressure/{bloodPressureId}",
+                            arguments = listOf(navArgument("bloodPressureId") { type = NavType.LongType })
+                        ) { backStackEntry ->
+                            val bloodPressureId = backStackEntry.arguments?.getLong("bloodPressureId")
+                            AddBloodPressureScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                editId = bloodPressureId
+                            )
+                        }
+                        composable(
+                            route = "edit_cholesterol/{cholesterolId}",
+                            arguments = listOf(navArgument("cholesterolId") { type = NavType.LongType })
+                        ) { backStackEntry ->
+                            val cholesterolId = backStackEntry.arguments?.getLong("cholesterolId")
+                            AddCholesterolScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                editId = cholesterolId
+                            )
+                        }
+                        composable(
+                            route = "edit_weight/{weightId}",
+                            arguments = listOf(navArgument("weightId") { type = NavType.LongType })
+                        ) { backStackEntry ->
+                            val weightId = backStackEntry.arguments?.getLong("weightId")
+                            AddWeightScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                editId = weightId
                             )
                         }
                     }

--- a/app/src/main/java/com/foodsymptomlog/data/AppDatabase.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/AppDatabase.kt
@@ -4,12 +4,17 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import com.foodsymptomlog.data.dao.BloodPressureDao
 import com.foodsymptomlog.data.dao.BowelMovementDao
+import com.foodsymptomlog.data.dao.CholesterolDao
 import com.foodsymptomlog.data.dao.MealDao
 import com.foodsymptomlog.data.dao.MedicationDao
 import com.foodsymptomlog.data.dao.OtherEntryDao
 import com.foodsymptomlog.data.dao.SymptomEntryDao
+import com.foodsymptomlog.data.dao.WeightDao
+import com.foodsymptomlog.data.entity.BloodPressureEntry
 import com.foodsymptomlog.data.entity.BowelMovementEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
 import com.foodsymptomlog.data.entity.FoodItem
 import com.foodsymptomlog.data.entity.MealEntry
 import com.foodsymptomlog.data.entity.MealTagCrossRef
@@ -17,6 +22,7 @@ import com.foodsymptomlog.data.entity.MedicationEntry
 import com.foodsymptomlog.data.entity.OtherEntry
 import com.foodsymptomlog.data.entity.SymptomEntry
 import com.foodsymptomlog.data.entity.Tag
+import com.foodsymptomlog.data.entity.WeightEntry
 
 @Database(
     entities = [
@@ -27,9 +33,12 @@ import com.foodsymptomlog.data.entity.Tag
         SymptomEntry::class,
         BowelMovementEntry::class,
         MedicationEntry::class,
-        OtherEntry::class
+        OtherEntry::class,
+        BloodPressureEntry::class,
+        CholesterolEntry::class,
+        WeightEntry::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -38,6 +47,9 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun bowelMovementDao(): BowelMovementDao
     abstract fun medicationDao(): MedicationDao
     abstract fun otherEntryDao(): OtherEntryDao
+    abstract fun bloodPressureDao(): BloodPressureDao
+    abstract fun cholesterolDao(): CholesterolDao
+    abstract fun weightDao(): WeightDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/foodsymptomlog/data/dao/BloodPressureDao.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/dao/BloodPressureDao.kt
@@ -1,0 +1,33 @@
+package com.foodsymptomlog.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.foodsymptomlog.data.entity.BloodPressureEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BloodPressureDao {
+    @Query("SELECT * FROM blood_pressure_entries ORDER BY timestamp DESC")
+    fun getAllBloodPressureEntries(): Flow<List<BloodPressureEntry>>
+
+    @Query("SELECT * FROM blood_pressure_entries ORDER BY timestamp DESC LIMIT :limit")
+    fun getRecentBloodPressureEntries(limit: Int): Flow<List<BloodPressureEntry>>
+
+    @Query("SELECT * FROM blood_pressure_entries WHERE id = :id")
+    suspend fun getById(id: Long): BloodPressureEntry?
+
+    @Insert
+    suspend fun insert(entry: BloodPressureEntry): Long
+
+    @Update
+    suspend fun update(entry: BloodPressureEntry)
+
+    @Delete
+    suspend fun delete(entry: BloodPressureEntry)
+
+    @Query("DELETE FROM blood_pressure_entries WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/foodsymptomlog/data/dao/CholesterolDao.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/dao/CholesterolDao.kt
@@ -1,0 +1,33 @@
+package com.foodsymptomlog.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.foodsymptomlog.data.entity.CholesterolEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CholesterolDao {
+    @Query("SELECT * FROM cholesterol_entries ORDER BY timestamp DESC")
+    fun getAllCholesterolEntries(): Flow<List<CholesterolEntry>>
+
+    @Query("SELECT * FROM cholesterol_entries ORDER BY timestamp DESC LIMIT :limit")
+    fun getRecentCholesterolEntries(limit: Int): Flow<List<CholesterolEntry>>
+
+    @Query("SELECT * FROM cholesterol_entries WHERE id = :id")
+    suspend fun getById(id: Long): CholesterolEntry?
+
+    @Insert
+    suspend fun insert(entry: CholesterolEntry): Long
+
+    @Update
+    suspend fun update(entry: CholesterolEntry)
+
+    @Delete
+    suspend fun delete(entry: CholesterolEntry)
+
+    @Query("DELETE FROM cholesterol_entries WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/foodsymptomlog/data/dao/WeightDao.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/dao/WeightDao.kt
@@ -1,0 +1,33 @@
+package com.foodsymptomlog.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.foodsymptomlog.data.entity.WeightEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WeightDao {
+    @Query("SELECT * FROM weight_entries ORDER BY timestamp DESC")
+    fun getAllWeightEntries(): Flow<List<WeightEntry>>
+
+    @Query("SELECT * FROM weight_entries ORDER BY timestamp DESC LIMIT :limit")
+    fun getRecentWeightEntries(limit: Int): Flow<List<WeightEntry>>
+
+    @Query("SELECT * FROM weight_entries WHERE id = :id")
+    suspend fun getById(id: Long): WeightEntry?
+
+    @Insert
+    suspend fun insert(entry: WeightEntry): Long
+
+    @Update
+    suspend fun update(entry: WeightEntry)
+
+    @Delete
+    suspend fun delete(entry: WeightEntry)
+
+    @Query("DELETE FROM weight_entries WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/foodsymptomlog/data/entity/BloodPressureEntry.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/entity/BloodPressureEntry.kt
@@ -1,0 +1,15 @@
+package com.foodsymptomlog.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "blood_pressure_entries")
+data class BloodPressureEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val systolic: Int,
+    val diastolic: Int,
+    val pulse: Int? = null,
+    val notes: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/foodsymptomlog/data/entity/CholesterolEntry.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/entity/CholesterolEntry.kt
@@ -1,0 +1,16 @@
+package com.foodsymptomlog.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "cholesterol_entries")
+data class CholesterolEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val total: Int? = null,
+    val ldl: Int? = null,
+    val hdl: Int? = null,
+    val triglycerides: Int? = null,
+    val notes: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/foodsymptomlog/data/entity/WeightEntry.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/entity/WeightEntry.kt
@@ -1,0 +1,19 @@
+package com.foodsymptomlog.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+enum class WeightUnit {
+    LB,
+    KG
+}
+
+@Entity(tableName = "weight_entries")
+data class WeightEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val weight: Double,
+    val unit: WeightUnit = WeightUnit.LB,
+    val notes: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/foodsymptomlog/data/export/DataExporter.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/export/DataExporter.kt
@@ -1,9 +1,12 @@
 package com.foodsymptomlog.data.export
 
+import com.foodsymptomlog.data.entity.BloodPressureEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
 import com.foodsymptomlog.data.entity.MealWithDetails
 import com.foodsymptomlog.data.entity.MedicationEntry
 import com.foodsymptomlog.data.entity.OtherEntry
 import com.foodsymptomlog.data.entity.SymptomEntry
+import com.foodsymptomlog.data.entity.WeightEntry
 import com.google.gson.GsonBuilder
 
 object DataExporter {
@@ -14,7 +17,10 @@ object DataExporter {
         meals: List<MealWithDetails>,
         symptoms: List<SymptomEntry>,
         medications: List<MedicationEntry>,
-        otherEntries: List<OtherEntry>
+        otherEntries: List<OtherEntry>,
+        bloodPressureEntries: List<BloodPressureEntry> = emptyList(),
+        cholesterolEntries: List<CholesterolEntry> = emptyList(),
+        weightEntries: List<WeightEntry> = emptyList()
     ): String {
         val exportData = ExportData(
             meals = meals.map { meal ->
@@ -50,6 +56,33 @@ object DataExporter {
                     value = other.value,
                     notes = other.notes,
                     timestamp = other.timestamp
+                )
+            },
+            bloodPressureEntries = bloodPressureEntries.map { bp ->
+                ExportedBloodPressure(
+                    systolic = bp.systolic,
+                    diastolic = bp.diastolic,
+                    pulse = bp.pulse,
+                    notes = bp.notes,
+                    timestamp = bp.timestamp
+                )
+            },
+            cholesterolEntries = cholesterolEntries.map { chol ->
+                ExportedCholesterol(
+                    total = chol.total,
+                    ldl = chol.ldl,
+                    hdl = chol.hdl,
+                    triglycerides = chol.triglycerides,
+                    notes = chol.notes,
+                    timestamp = chol.timestamp
+                )
+            },
+            weightEntries = weightEntries.map { weight ->
+                ExportedWeight(
+                    weight = weight.weight,
+                    unit = weight.unit.name,
+                    notes = weight.notes,
+                    timestamp = weight.timestamp
                 )
             }
         )

--- a/app/src/main/java/com/foodsymptomlog/data/export/ExportData.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/export/ExportData.kt
@@ -1,12 +1,15 @@
 package com.foodsymptomlog.data.export
 
 data class ExportData(
-    val version: Int = 1,
+    val version: Int = 2,
     val exportedAt: Long = System.currentTimeMillis(),
     val meals: List<ExportedMeal> = emptyList(),
     val symptoms: List<ExportedSymptom> = emptyList(),
     val medications: List<ExportedMedication> = emptyList(),
-    val otherEntries: List<ExportedOtherEntry> = emptyList()
+    val otherEntries: List<ExportedOtherEntry> = emptyList(),
+    val bloodPressureEntries: List<ExportedBloodPressure> = emptyList(),
+    val cholesterolEntries: List<ExportedCholesterol> = emptyList(),
+    val weightEntries: List<ExportedWeight> = emptyList()
 )
 
 data class ExportedMeal(
@@ -36,6 +39,30 @@ data class ExportedOtherEntry(
     val entryType: String,
     val subType: String,
     val value: String,
+    val notes: String,
+    val timestamp: Long
+)
+
+data class ExportedBloodPressure(
+    val systolic: Int,
+    val diastolic: Int,
+    val pulse: Int?,
+    val notes: String,
+    val timestamp: Long
+)
+
+data class ExportedCholesterol(
+    val total: Int?,
+    val ldl: Int?,
+    val hdl: Int?,
+    val triglycerides: Int?,
+    val notes: String,
+    val timestamp: Long
+)
+
+data class ExportedWeight(
+    val weight: Double,
+    val unit: String,
     val notes: String,
     val timestamp: Long
 )

--- a/app/src/main/java/com/foodsymptomlog/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/foodsymptomlog/data/repository/LogRepository.kt
@@ -1,11 +1,16 @@
 package com.foodsymptomlog.data.repository
 
+import com.foodsymptomlog.data.dao.BloodPressureDao
 import com.foodsymptomlog.data.dao.BowelMovementDao
+import com.foodsymptomlog.data.dao.CholesterolDao
 import com.foodsymptomlog.data.dao.MealDao
 import com.foodsymptomlog.data.dao.MedicationDao
 import com.foodsymptomlog.data.dao.OtherEntryDao
 import com.foodsymptomlog.data.dao.SymptomEntryDao
+import com.foodsymptomlog.data.dao.WeightDao
+import com.foodsymptomlog.data.entity.BloodPressureEntry
 import com.foodsymptomlog.data.entity.BowelMovementEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
 import com.foodsymptomlog.data.entity.MealEntry
 import com.foodsymptomlog.data.entity.MealType
 import com.foodsymptomlog.data.entity.MealWithDetails
@@ -13,6 +18,7 @@ import com.foodsymptomlog.data.entity.MedicationEntry
 import com.foodsymptomlog.data.entity.OtherEntry
 import com.foodsymptomlog.data.entity.SymptomEntry
 import com.foodsymptomlog.data.entity.Tag
+import com.foodsymptomlog.data.entity.WeightEntry
 import kotlinx.coroutines.flow.Flow
 
 class LogRepository(
@@ -20,7 +26,10 @@ class LogRepository(
     private val symptomEntryDao: SymptomEntryDao,
     private val bowelMovementDao: BowelMovementDao,
     private val medicationDao: MedicationDao,
-    private val otherEntryDao: OtherEntryDao
+    private val otherEntryDao: OtherEntryDao,
+    private val bloodPressureDao: BloodPressureDao,
+    private val cholesterolDao: CholesterolDao,
+    private val weightDao: WeightDao
 ) {
     val allMeals: Flow<List<MealWithDetails>> = mealDao.getAllMealsWithDetails()
     val allSymptomEntries: Flow<List<SymptomEntry>> = symptomEntryDao.getAllSymptomEntries()
@@ -30,6 +39,9 @@ class LogRepository(
     val allMedications: Flow<List<MedicationEntry>> = medicationDao.getAllMedications()
     val allMedicationNames: Flow<List<String>> = medicationDao.getAllMedicationNames()
     val allOtherEntries: Flow<List<OtherEntry>> = otherEntryDao.getAllOtherEntries()
+    val allBloodPressureEntries: Flow<List<BloodPressureEntry>> = bloodPressureDao.getAllBloodPressureEntries()
+    val allCholesterolEntries: Flow<List<CholesterolEntry>> = cholesterolDao.getAllCholesterolEntries()
+    val allWeightEntries: Flow<List<WeightEntry>> = weightDao.getAllWeightEntries()
 
     fun getRecentMeals(limit: Int = 5): Flow<List<MealWithDetails>> {
         return mealDao.getRecentMealsWithDetails(limit)
@@ -49,6 +61,18 @@ class LogRepository(
 
     fun getRecentOtherEntries(limit: Int = 5): Flow<List<OtherEntry>> {
         return otherEntryDao.getRecentOtherEntries(limit)
+    }
+
+    fun getRecentBloodPressureEntries(limit: Int = 5): Flow<List<BloodPressureEntry>> {
+        return bloodPressureDao.getRecentBloodPressureEntries(limit)
+    }
+
+    fun getRecentCholesterolEntries(limit: Int = 5): Flow<List<CholesterolEntry>> {
+        return cholesterolDao.getRecentCholesterolEntries(limit)
+    }
+
+    fun getRecentWeightEntries(limit: Int = 5): Flow<List<WeightEntry>> {
+        return weightDao.getRecentWeightEntries(limit)
     }
 
     suspend fun insertMeal(
@@ -160,5 +184,56 @@ class LogRepository(
 
     suspend fun getOtherEntryById(id: Long): OtherEntry? {
         return otherEntryDao.getById(id)
+    }
+
+    // Blood Pressure methods
+    suspend fun insertBloodPressure(entry: BloodPressureEntry): Long {
+        return bloodPressureDao.insert(entry)
+    }
+
+    suspend fun updateBloodPressure(entry: BloodPressureEntry) {
+        bloodPressureDao.update(entry)
+    }
+
+    suspend fun deleteBloodPressure(entry: BloodPressureEntry) {
+        bloodPressureDao.delete(entry)
+    }
+
+    suspend fun getBloodPressureById(id: Long): BloodPressureEntry? {
+        return bloodPressureDao.getById(id)
+    }
+
+    // Cholesterol methods
+    suspend fun insertCholesterol(entry: CholesterolEntry): Long {
+        return cholesterolDao.insert(entry)
+    }
+
+    suspend fun updateCholesterol(entry: CholesterolEntry) {
+        cholesterolDao.update(entry)
+    }
+
+    suspend fun deleteCholesterol(entry: CholesterolEntry) {
+        cholesterolDao.delete(entry)
+    }
+
+    suspend fun getCholesterolById(id: Long): CholesterolEntry? {
+        return cholesterolDao.getById(id)
+    }
+
+    // Weight methods
+    suspend fun insertWeight(entry: WeightEntry): Long {
+        return weightDao.insert(entry)
+    }
+
+    suspend fun updateWeight(entry: WeightEntry) {
+        weightDao.update(entry)
+    }
+
+    suspend fun deleteWeight(entry: WeightEntry) {
+        weightDao.delete(entry)
+    }
+
+    suspend fun getWeightById(id: Long): WeightEntry? {
+        return weightDao.getById(id)
     }
 }

--- a/app/src/main/java/com/foodsymptomlog/ui/components/BloodPressureCard.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/components/BloodPressureCard.kt
@@ -1,0 +1,126 @@
+package com.foodsymptomlog.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.BloodPressureEntry
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun BloodPressureCard(
+    entry: BloodPressureEntry,
+    onDelete: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = "Blood Pressure",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Blood Pressure",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "${entry.systolic}/${entry.diastolic} mmHg",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = getBloodPressureColor(entry.systolic, entry.diastolic)
+                )
+                entry.pulse?.let { pulse ->
+                    Text(
+                        text = "Pulse: $pulse bpm",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (entry.notes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatTimestamp(entry.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+            Column {
+                if (onEdit != null) {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun getBloodPressureColor(systolic: Int, diastolic: Int) = when {
+    systolic >= 180 || diastolic >= 120 -> MaterialTheme.colorScheme.error
+    systolic >= 140 || diastolic >= 90 -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+    systolic >= 130 || diastolic >= 80 -> MaterialTheme.colorScheme.tertiary
+    systolic >= 120 -> MaterialTheme.colorScheme.secondary
+    else -> MaterialTheme.colorScheme.primary
+}
+
+private fun formatTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy 'at' h:mm a", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/components/CholesterolCard.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/components/CholesterolCard.kt
@@ -1,0 +1,126 @@
+package com.foodsymptomlog.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bloodtype
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.CholesterolEntry
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun CholesterolCard(
+    entry: CholesterolEntry,
+    onDelete: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.Bloodtype,
+                contentDescription = "Cholesterol",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Cholesterol",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+
+                val values = buildList {
+                    entry.total?.let { add("Total: $it") }
+                    entry.ldl?.let { add("LDL: $it") }
+                    entry.hdl?.let { add("HDL: $it") }
+                    entry.triglycerides?.let { add("Triglycerides: $it") }
+                }
+
+                if (values.isNotEmpty()) {
+                    Text(
+                        text = values.joinToString(" | "),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = "No values recorded",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+
+                if (entry.notes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatTimestamp(entry.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+            Column {
+                if (onEdit != null) {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy 'at' h:mm a", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/components/WeightCard.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/components/WeightCard.kt
@@ -1,0 +1,123 @@
+package com.foodsymptomlog.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MonitorWeight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.WeightEntry
+import com.foodsymptomlog.data.entity.WeightUnit
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun WeightCard(
+    entry: WeightEntry,
+    onDelete: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.MonitorWeight,
+                contentDescription = "Weight",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Weight",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                val unitLabel = when (entry.unit) {
+                    WeightUnit.LB -> "lbs"
+                    WeightUnit.KG -> "kg"
+                }
+                Text(
+                    text = "${formatWeight(entry.weight)} $unitLabel",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                if (entry.notes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatTimestamp(entry.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+            Column {
+                if (onEdit != null) {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatWeight(weight: Double): String {
+    return if (weight == weight.toLong().toDouble()) {
+        weight.toLong().toString()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", weight)
+    }
+}
+
+private fun formatTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy 'at' h:mm a", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddBloodPressureScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddBloodPressureScreen.kt
@@ -1,0 +1,223 @@
+package com.foodsymptomlog.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.BloodPressureEntry
+import com.foodsymptomlog.ui.components.DateTimePicker
+import com.foodsymptomlog.viewmodel.LogViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddBloodPressureScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    editId: Long? = null
+) {
+    val editingEntry by viewModel.editingBloodPressure.collectAsState()
+    val isEditMode = editId != null
+
+    var systolic by remember { mutableStateOf("") }
+    var diastolic by remember { mutableStateOf("") }
+    var pulse by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(editId) {
+        if (editId != null) {
+            viewModel.loadBloodPressureForEditing(editId)
+        }
+    }
+
+    LaunchedEffect(editingEntry) {
+        editingEntry?.let { entry ->
+            systolic = entry.systolic.toString()
+            diastolic = entry.diastolic.toString()
+            pulse = entry.pulse?.toString() ?: ""
+            notes = entry.notes
+            timestamp = entry.timestamp
+            existingId = entry.id
+        }
+    }
+
+    val isValid = systolic.toIntOrNull() != null && diastolic.toIntOrNull() != null
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        if (isEditMode) "Edit Blood Pressure" else "Log Blood Pressure",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.clearEditingState()
+                        onNavigateBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Blood Pressure Reading",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = systolic,
+                    onValueChange = { systolic = it.filter { c -> c.isDigit() } },
+                    label = { Text("Systolic") },
+                    placeholder = { Text("120") },
+                    suffix = { Text("mmHg") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                OutlinedTextField(
+                    value = diastolic,
+                    onValueChange = { diastolic = it.filter { c -> c.isDigit() } },
+                    label = { Text("Diastolic") },
+                    placeholder = { Text("80") },
+                    suffix = { Text("mmHg") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = pulse,
+                onValueChange = { pulse = it.filter { c -> c.isDigit() } },
+                label = { Text("Pulse (optional)") },
+                placeholder = { Text("72") },
+                suffix = { Text("bpm") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DateTimePicker(
+                timestamp = timestamp,
+                onTimestampChange = { timestamp = it },
+                label = "Date & Time"
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes (optional)") },
+                placeholder = { Text("Any additional details...") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                maxLines = 3
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    val sys = systolic.toIntOrNull() ?: return@Button
+                    val dia = diastolic.toIntOrNull() ?: return@Button
+                    val pul = pulse.toIntOrNull()
+
+                    if (isEditMode && existingId != null) {
+                        viewModel.updateBloodPressure(
+                            BloodPressureEntry(
+                                id = existingId!!,
+                                systolic = sys,
+                                diastolic = dia,
+                                pulse = pul,
+                                notes = notes.trim(),
+                                timestamp = timestamp
+                            )
+                        )
+                    } else {
+                        viewModel.addBloodPressure(
+                            systolic = sys,
+                            diastolic = dia,
+                            pulse = pul,
+                            notes = notes.trim(),
+                            timestamp = timestamp
+                        )
+                    }
+                    viewModel.clearEditingState()
+                    onNavigateBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = isValid
+            ) {
+                Text(if (isEditMode) "Update Blood Pressure" else "Save Blood Pressure")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddCholesterolScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddCholesterolScreen.kt
@@ -1,0 +1,242 @@
+package com.foodsymptomlog.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bloodtype
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.CholesterolEntry
+import com.foodsymptomlog.ui.components.DateTimePicker
+import com.foodsymptomlog.viewmodel.LogViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddCholesterolScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    editId: Long? = null
+) {
+    val editingEntry by viewModel.editingCholesterol.collectAsState()
+    val isEditMode = editId != null
+
+    var total by remember { mutableStateOf("") }
+    var ldl by remember { mutableStateOf("") }
+    var hdl by remember { mutableStateOf("") }
+    var triglycerides by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(editId) {
+        if (editId != null) {
+            viewModel.loadCholesterolForEditing(editId)
+        }
+    }
+
+    LaunchedEffect(editingEntry) {
+        editingEntry?.let { entry ->
+            total = entry.total?.toString() ?: ""
+            ldl = entry.ldl?.toString() ?: ""
+            hdl = entry.hdl?.toString() ?: ""
+            triglycerides = entry.triglycerides?.toString() ?: ""
+            notes = entry.notes
+            timestamp = entry.timestamp
+            existingId = entry.id
+        }
+    }
+
+    val hasAtLeastOneValue = total.isNotBlank() || ldl.isNotBlank() || hdl.isNotBlank() || triglycerides.isNotBlank()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        if (isEditMode) "Edit Cholesterol" else "Log Cholesterol",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.clearEditingState()
+                        onNavigateBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Icon(
+                imageVector = Icons.Default.Bloodtype,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Cholesterol Levels",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Text(
+                text = "Enter at least one value",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = total,
+                    onValueChange = { total = it.filter { c -> c.isDigit() } },
+                    label = { Text("Total") },
+                    placeholder = { Text("200") },
+                    suffix = { Text("mg/dL") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                OutlinedTextField(
+                    value = ldl,
+                    onValueChange = { ldl = it.filter { c -> c.isDigit() } },
+                    label = { Text("LDL") },
+                    placeholder = { Text("100") },
+                    suffix = { Text("mg/dL") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = hdl,
+                    onValueChange = { hdl = it.filter { c -> c.isDigit() } },
+                    label = { Text("HDL") },
+                    placeholder = { Text("60") },
+                    suffix = { Text("mg/dL") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                OutlinedTextField(
+                    value = triglycerides,
+                    onValueChange = { triglycerides = it.filter { c -> c.isDigit() } },
+                    label = { Text("Triglycerides") },
+                    placeholder = { Text("150") },
+                    suffix = { Text("mg/dL") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DateTimePicker(
+                timestamp = timestamp,
+                onTimestampChange = { timestamp = it },
+                label = "Date & Time"
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes (optional)") },
+                placeholder = { Text("Any additional details...") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                maxLines = 3
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    val entry = CholesterolEntry(
+                        id = existingId ?: 0,
+                        total = total.toIntOrNull(),
+                        ldl = ldl.toIntOrNull(),
+                        hdl = hdl.toIntOrNull(),
+                        triglycerides = triglycerides.toIntOrNull(),
+                        notes = notes.trim(),
+                        timestamp = timestamp
+                    )
+
+                    if (isEditMode && existingId != null) {
+                        viewModel.updateCholesterol(entry)
+                    } else {
+                        viewModel.addCholesterol(
+                            total = total.toIntOrNull(),
+                            ldl = ldl.toIntOrNull(),
+                            hdl = hdl.toIntOrNull(),
+                            triglycerides = triglycerides.toIntOrNull(),
+                            notes = notes.trim(),
+                            timestamp = timestamp
+                        )
+                    }
+                    viewModel.clearEditingState()
+                    onNavigateBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = hasAtLeastOneValue
+            ) {
+                Text(if (isEditMode) "Update Cholesterol" else "Save Cholesterol")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddMealScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddMealScreen.kt
@@ -60,12 +60,17 @@ import com.foodsymptomlog.viewmodel.LogViewModel
 fun AddMealScreen(
     viewModel: LogViewModel,
     onNavigateBack: () -> Unit,
-    editId: Long? = null
+    editId: Long? = null,
+    preselectedMealType: String? = null
 ) {
     val editingMeal by viewModel.editingMeal.collectAsState()
     val isEditMode = editId != null
 
-    var selectedMealType by remember { mutableStateOf(MealType.BREAKFAST) }
+    val initialMealType = preselectedMealType?.let {
+        try { MealType.valueOf(it) } catch (e: IllegalArgumentException) { MealType.BREAKFAST }
+    } ?: MealType.BREAKFAST
+
+    var selectedMealType by remember { mutableStateOf(initialMealType) }
     val foods = remember { mutableStateListOf<String>() }
     var currentFood by remember { mutableStateOf("") }
     val tags = remember { mutableStateListOf<String>() }

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddMedicationScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddMedicationScreen.kt
@@ -47,13 +47,14 @@ import com.foodsymptomlog.viewmodel.LogViewModel
 fun AddMedicationScreen(
     viewModel: LogViewModel,
     onNavigateBack: () -> Unit,
-    editId: Long? = null
+    editId: Long? = null,
+    prefillName: String? = null
 ) {
     val editingMedication by viewModel.editingMedication.collectAsState()
     val medicationNames by viewModel.allMedicationNames.collectAsState()
     val isEditMode = editId != null
 
-    var name by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf(prefillName ?: "") }
     var dosage by remember { mutableStateOf("") }
     var notes by remember { mutableStateOf("") }
     var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddOtherEntryScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddOtherEntryScreen.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -57,10 +55,14 @@ fun AddOtherEntryScreen(
     viewModel: LogViewModel,
     onNavigateBack: () -> Unit,
     editId: Long? = null,
-    initialType: OtherEntryType = OtherEntryType.BOWEL_MOVEMENT
+    preselectedType: String? = null
 ) {
     val editingOtherEntry by viewModel.editingOtherEntry.collectAsState()
     val isEditMode = editId != null
+
+    val initialType = preselectedType?.let {
+        try { OtherEntryType.valueOf(it) } catch (e: IllegalArgumentException) { OtherEntryType.BOWEL_MOVEMENT }
+    } ?: OtherEntryType.BOWEL_MOVEMENT
 
     var selectedType by remember { mutableStateOf(initialType) }
     var subType by remember { mutableStateOf("") }
@@ -94,12 +96,18 @@ fun AddOtherEntryScreen(
         }
     }
 
+    val screenTitle = if (isEditMode) {
+        "Edit ${getTypeTitle(selectedType)}"
+    } else {
+        "Log ${getTypeTitle(selectedType)}"
+    }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
                     Text(
-                        if (isEditMode) "Edit Entry" else "Log Other",
+                        screenTitle,
                         fontWeight = FontWeight.Bold
                     )
                 },
@@ -127,51 +135,6 @@ fun AddOtherEntryScreen(
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState())
         ) {
-            // Type selection
-            Text(
-                text = "Entry Type",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Medium
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OtherEntryType.entries.take(3).forEach { type ->
-                    FilterChip(
-                        selected = selectedType == type,
-                        onClick = { selectedType = type },
-                        label = { Text(getTypeDisplayName(type)) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.tertiary,
-                            selectedLabelColor = MaterialTheme.colorScheme.onTertiary
-                        )
-                    )
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OtherEntryType.entries.drop(3).forEach { type ->
-                    FilterChip(
-                        selected = selectedType == type,
-                        onClick = { selectedType = type },
-                        label = { Text(getTypeDisplayName(type)) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.tertiary,
-                            selectedLabelColor = MaterialTheme.colorScheme.onTertiary
-                        )
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
             // Type-specific fields
             when (selectedType) {
                 OtherEntryType.BOWEL_MOVEMENT -> {
@@ -475,13 +438,14 @@ private fun getBristolVisualSize(type: Int) = when (type) {
     1 -> 8.dp; 2 -> 10.dp; 7 -> 6.dp; else -> 8.dp
 }
 
-private fun getTypeDisplayName(type: OtherEntryType): String {
+private fun getTypeTitle(type: OtherEntryType): String {
     return when (type) {
-        OtherEntryType.BOWEL_MOVEMENT -> "BM"
+        OtherEntryType.BOWEL_MOVEMENT -> "Bowel Movement"
         OtherEntryType.SLEEP -> "Sleep"
         OtherEntryType.EXERCISE -> "Exercise"
         OtherEntryType.STRESS -> "Stress"
-        OtherEntryType.WATER_INTAKE -> "Water"
+        OtherEntryType.WATER_INTAKE -> "Water Intake"
         OtherEntryType.OTHER -> "Other"
     }
 }
+

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddSymptomScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddSymptomScreen.kt
@@ -50,12 +50,13 @@ import kotlin.math.roundToInt
 fun AddSymptomScreen(
     viewModel: LogViewModel,
     onNavigateBack: () -> Unit,
-    editId: Long? = null
+    editId: Long? = null,
+    prefillName: String? = null
 ) {
     val editingSymptom by viewModel.editingSymptom.collectAsState()
     val isEditMode = editId != null
 
-    var symptomName by remember { mutableStateOf("") }
+    var symptomName by remember { mutableStateOf(prefillName ?: "") }
     var severity by remember { mutableFloatStateOf(3f) }
     var notes by remember { mutableStateOf("") }
     var existingId by remember { mutableStateOf<Long?>(null) }

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/AddWeightScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/AddWeightScreen.kt
@@ -1,0 +1,235 @@
+package com.foodsymptomlog.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.MonitorWeight
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.WeightEntry
+import com.foodsymptomlog.data.entity.WeightUnit
+import com.foodsymptomlog.ui.components.DateTimePicker
+import com.foodsymptomlog.viewmodel.LogViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AddWeightScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    editId: Long? = null
+) {
+    val editingEntry by viewModel.editingWeight.collectAsState()
+    val isEditMode = editId != null
+
+    var weight by remember { mutableStateOf("") }
+    var unit by remember { mutableStateOf(WeightUnit.LB) }
+    var notes by remember { mutableStateOf("") }
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(editId) {
+        if (editId != null) {
+            viewModel.loadWeightForEditing(editId)
+        }
+    }
+
+    LaunchedEffect(editingEntry) {
+        editingEntry?.let { entry ->
+            weight = entry.weight.toString()
+            unit = entry.unit
+            notes = entry.notes
+            timestamp = entry.timestamp
+            existingId = entry.id
+        }
+    }
+
+    val isValid = weight.toDoubleOrNull() != null && weight.toDoubleOrNull()!! > 0
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        if (isEditMode) "Edit Weight" else "Log Weight",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.clearEditingState()
+                        onNavigateBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Icon(
+                imageVector = Icons.Default.MonitorWeight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Weight",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = weight,
+                onValueChange = { input ->
+                    // Allow digits and one decimal point
+                    val filtered = input.filter { it.isDigit() || it == '.' }
+                    if (filtered.count { it == '.' } <= 1) {
+                        weight = filtered
+                    }
+                },
+                label = { Text("Weight") },
+                placeholder = { Text(if (unit == WeightUnit.LB) "150" else "68") },
+                suffix = { Text(if (unit == WeightUnit.LB) "lbs" else "kg") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Unit",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                WeightUnit.entries.forEach { weightUnit ->
+                    FilterChip(
+                        selected = unit == weightUnit,
+                        onClick = { unit = weightUnit },
+                        label = {
+                            Text(
+                                when (weightUnit) {
+                                    WeightUnit.LB -> "Pounds (lbs)"
+                                    WeightUnit.KG -> "Kilograms (kg)"
+                                }
+                            )
+                        },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary
+                        )
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DateTimePicker(
+                timestamp = timestamp,
+                onTimestampChange = { timestamp = it },
+                label = "Date & Time"
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes (optional)") },
+                placeholder = { Text("Any additional details...") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                maxLines = 3
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    val weightValue = weight.toDoubleOrNull() ?: return@Button
+
+                    if (isEditMode && existingId != null) {
+                        viewModel.updateWeight(
+                            WeightEntry(
+                                id = existingId!!,
+                                weight = weightValue,
+                                unit = unit,
+                                notes = notes.trim(),
+                                timestamp = timestamp
+                            )
+                        )
+                    } else {
+                        viewModel.addWeight(
+                            weight = weightValue,
+                            unit = unit,
+                            notes = notes.trim(),
+                            timestamp = timestamp
+                        )
+                    }
+                    viewModel.clearEditingState()
+                    onNavigateBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = isValid
+            ) {
+                Text(if (isEditMode) "Update Weight" else "Save Weight")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/foodsymptomlog/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/foodsymptomlog/viewmodel/LogViewModel.kt
@@ -8,7 +8,9 @@ import com.foodsymptomlog.data.AppDatabase
 import com.foodsymptomlog.data.export.DataExporter
 import com.foodsymptomlog.data.export.DataImporter
 import com.foodsymptomlog.data.export.ImportResult
+import com.foodsymptomlog.data.entity.BloodPressureEntry
 import com.foodsymptomlog.data.entity.BowelMovementEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
 import com.foodsymptomlog.data.entity.MealEntry
 import com.foodsymptomlog.data.entity.MealType
 import com.foodsymptomlog.data.entity.MealWithDetails
@@ -16,6 +18,8 @@ import com.foodsymptomlog.data.entity.MedicationEntry
 import com.foodsymptomlog.data.entity.OtherEntry
 import com.foodsymptomlog.data.entity.SymptomEntry
 import com.foodsymptomlog.data.entity.Tag
+import com.foodsymptomlog.data.entity.WeightEntry
+import com.foodsymptomlog.data.entity.WeightUnit
 import com.foodsymptomlog.data.repository.LogRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,12 +36,18 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     val allBowelMovements: StateFlow<List<BowelMovementEntry>>
     val allMedications: StateFlow<List<MedicationEntry>>
     val allOtherEntries: StateFlow<List<OtherEntry>>
+    val allBloodPressureEntries: StateFlow<List<BloodPressureEntry>>
+    val allCholesterolEntries: StateFlow<List<CholesterolEntry>>
+    val allWeightEntries: StateFlow<List<WeightEntry>>
     val ongoingSymptoms: StateFlow<List<SymptomEntry>>
     val recentMeals: StateFlow<List<MealWithDetails>>
     val recentSymptomEntries: StateFlow<List<SymptomEntry>>
     val recentBowelMovements: StateFlow<List<BowelMovementEntry>>
     val recentMedications: StateFlow<List<MedicationEntry>>
     val recentOtherEntries: StateFlow<List<OtherEntry>>
+    val recentBloodPressureEntries: StateFlow<List<BloodPressureEntry>>
+    val recentCholesterolEntries: StateFlow<List<CholesterolEntry>>
+    val recentWeightEntries: StateFlow<List<WeightEntry>>
     val allTags: StateFlow<List<Tag>>
     val allMedicationNames: StateFlow<List<String>>
 
@@ -48,7 +58,10 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             database.symptomEntryDao(),
             database.bowelMovementDao(),
             database.medicationDao(),
-            database.otherEntryDao()
+            database.otherEntryDao(),
+            database.bloodPressureDao(),
+            database.cholesterolDao(),
+            database.weightDao()
         )
 
         allMeals = repository.allMeals
@@ -64,6 +77,15 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
         allOtherEntries = repository.allOtherEntries
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        allBloodPressureEntries = repository.allBloodPressureEntries
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        allCholesterolEntries = repository.allCholesterolEntries
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        allWeightEntries = repository.allWeightEntries
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
         ongoingSymptoms = repository.ongoingSymptoms
@@ -82,6 +104,15 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
         recentOtherEntries = repository.getRecentOtherEntries(5)
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        recentBloodPressureEntries = repository.getRecentBloodPressureEntries(5)
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        recentCholesterolEntries = repository.getRecentCholesterolEntries(5)
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        recentWeightEntries = repository.getRecentWeightEntries(5)
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
         allTags = repository.allTags
@@ -204,6 +235,105 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    // Blood Pressure methods
+    fun addBloodPressure(
+        systolic: Int,
+        diastolic: Int,
+        pulse: Int? = null,
+        notes: String = "",
+        timestamp: Long = System.currentTimeMillis()
+    ) {
+        viewModelScope.launch {
+            repository.insertBloodPressure(
+                BloodPressureEntry(
+                    systolic = systolic,
+                    diastolic = diastolic,
+                    pulse = pulse,
+                    notes = notes,
+                    timestamp = timestamp
+                )
+            )
+        }
+    }
+
+    fun updateBloodPressure(entry: BloodPressureEntry) {
+        viewModelScope.launch {
+            repository.updateBloodPressure(entry)
+        }
+    }
+
+    fun deleteBloodPressure(entry: BloodPressureEntry) {
+        viewModelScope.launch {
+            repository.deleteBloodPressure(entry)
+        }
+    }
+
+    // Cholesterol methods
+    fun addCholesterol(
+        total: Int? = null,
+        ldl: Int? = null,
+        hdl: Int? = null,
+        triglycerides: Int? = null,
+        notes: String = "",
+        timestamp: Long = System.currentTimeMillis()
+    ) {
+        viewModelScope.launch {
+            repository.insertCholesterol(
+                CholesterolEntry(
+                    total = total,
+                    ldl = ldl,
+                    hdl = hdl,
+                    triglycerides = triglycerides,
+                    notes = notes,
+                    timestamp = timestamp
+                )
+            )
+        }
+    }
+
+    fun updateCholesterol(entry: CholesterolEntry) {
+        viewModelScope.launch {
+            repository.updateCholesterol(entry)
+        }
+    }
+
+    fun deleteCholesterol(entry: CholesterolEntry) {
+        viewModelScope.launch {
+            repository.deleteCholesterol(entry)
+        }
+    }
+
+    // Weight methods
+    fun addWeight(
+        weight: Double,
+        unit: WeightUnit = WeightUnit.LB,
+        notes: String = "",
+        timestamp: Long = System.currentTimeMillis()
+    ) {
+        viewModelScope.launch {
+            repository.insertWeight(
+                WeightEntry(
+                    weight = weight,
+                    unit = unit,
+                    notes = notes,
+                    timestamp = timestamp
+                )
+            )
+        }
+    }
+
+    fun updateWeight(entry: WeightEntry) {
+        viewModelScope.launch {
+            repository.updateWeight(entry)
+        }
+    }
+
+    fun deleteWeight(entry: WeightEntry) {
+        viewModelScope.launch {
+            repository.deleteWeight(entry)
+        }
+    }
+
     // Update methods
     fun updateSymptom(symptomEntry: SymptomEntry) {
         viewModelScope.launch {
@@ -243,6 +373,15 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     private val _editingOtherEntry = MutableStateFlow<OtherEntry?>(null)
     val editingOtherEntry: StateFlow<OtherEntry?> = _editingOtherEntry.asStateFlow()
 
+    private val _editingBloodPressure = MutableStateFlow<BloodPressureEntry?>(null)
+    val editingBloodPressure: StateFlow<BloodPressureEntry?> = _editingBloodPressure.asStateFlow()
+
+    private val _editingCholesterol = MutableStateFlow<CholesterolEntry?>(null)
+    val editingCholesterol: StateFlow<CholesterolEntry?> = _editingCholesterol.asStateFlow()
+
+    private val _editingWeight = MutableStateFlow<WeightEntry?>(null)
+    val editingWeight: StateFlow<WeightEntry?> = _editingWeight.asStateFlow()
+
     fun loadSymptomForEditing(id: Long) {
         viewModelScope.launch {
             _editingSymptom.value = repository.getSymptomById(id)
@@ -273,12 +412,33 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun loadBloodPressureForEditing(id: Long) {
+        viewModelScope.launch {
+            _editingBloodPressure.value = repository.getBloodPressureById(id)
+        }
+    }
+
+    fun loadCholesterolForEditing(id: Long) {
+        viewModelScope.launch {
+            _editingCholesterol.value = repository.getCholesterolById(id)
+        }
+    }
+
+    fun loadWeightForEditing(id: Long) {
+        viewModelScope.launch {
+            _editingWeight.value = repository.getWeightById(id)
+        }
+    }
+
     fun clearEditingState() {
         _editingSymptom.value = null
         _editingBowelMovement.value = null
         _editingMeal.value = null
         _editingMedication.value = null
         _editingOtherEntry.value = null
+        _editingBloodPressure.value = null
+        _editingCholesterol.value = null
+        _editingWeight.value = null
     }
 
     // Export/Import
@@ -289,13 +449,18 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
                     meals = allMeals.value,
                     symptoms = allSymptomEntries.value,
                     medications = allMedications.value,
-                    otherEntries = allOtherEntries.value
+                    otherEntries = allOtherEntries.value,
+                    bloodPressureEntries = allBloodPressureEntries.value,
+                    cholesterolEntries = allCholesterolEntries.value,
+                    weightEntries = allWeightEntries.value
                 )
                 getApplication<Application>().contentResolver.openOutputStream(uri)?.use { stream ->
                     stream.write(json.toByteArray())
                 }
                 val total = allMeals.value.size + allSymptomEntries.value.size +
-                    allMedications.value.size + allOtherEntries.value.size
+                    allMedications.value.size + allOtherEntries.value.size +
+                    allBloodPressureEntries.value.size + allCholesterolEntries.value.size +
+                    allWeightEntries.value.size
                 onResult(true, "Exported $total entries successfully")
             } catch (e: Exception) {
                 onResult(false, "Export failed: ${e.message}")

--- a/app/src/test/java/com/foodsymptomlog/data/export/DataExporterTest.kt
+++ b/app/src/test/java/com/foodsymptomlog/data/export/DataExporterTest.kt
@@ -34,7 +34,7 @@ class DataExporterTest {
         )
 
         val result = gson.fromJson(json, ExportData::class.java)
-        assertThat(result.version).isEqualTo(1)
+        assertThat(result.version).isEqualTo(2)
         assertThat(result.exportedAt).isGreaterThan(0L)
     }
 

--- a/app/src/test/java/com/foodsymptomlog/repository/LogRepositoryTest.kt
+++ b/app/src/test/java/com/foodsymptomlog/repository/LogRepositoryTest.kt
@@ -1,10 +1,13 @@
 package com.foodsymptomlog.repository
 
+import com.foodsymptomlog.data.dao.BloodPressureDao
 import com.foodsymptomlog.data.dao.BowelMovementDao
+import com.foodsymptomlog.data.dao.CholesterolDao
 import com.foodsymptomlog.data.dao.MealDao
 import com.foodsymptomlog.data.dao.MedicationDao
 import com.foodsymptomlog.data.dao.OtherEntryDao
 import com.foodsymptomlog.data.dao.SymptomEntryDao
+import com.foodsymptomlog.data.dao.WeightDao
 import com.foodsymptomlog.data.entity.MealType
 import com.foodsymptomlog.data.repository.LogRepository
 import com.foodsymptomlog.util.TestData
@@ -25,6 +28,9 @@ class LogRepositoryTest {
     private lateinit var bowelMovementDao: BowelMovementDao
     private lateinit var medicationDao: MedicationDao
     private lateinit var otherEntryDao: OtherEntryDao
+    private lateinit var bloodPressureDao: BloodPressureDao
+    private lateinit var cholesterolDao: CholesterolDao
+    private lateinit var weightDao: WeightDao
     private lateinit var repository: LogRepository
 
     @Before
@@ -34,6 +40,9 @@ class LogRepositoryTest {
         bowelMovementDao = mockk(relaxed = true)
         medicationDao = mockk(relaxed = true)
         otherEntryDao = mockk(relaxed = true)
+        bloodPressureDao = mockk(relaxed = true)
+        cholesterolDao = mockk(relaxed = true)
+        weightDao = mockk(relaxed = true)
 
         every { mealDao.getAllMealsWithDetails() } returns flowOf(emptyList())
         every { mealDao.getAllTags() } returns flowOf(emptyList())
@@ -43,13 +52,19 @@ class LogRepositoryTest {
         every { medicationDao.getAllMedications() } returns flowOf(emptyList())
         every { medicationDao.getAllMedicationNames() } returns flowOf(emptyList())
         every { otherEntryDao.getAllOtherEntries() } returns flowOf(emptyList())
+        every { bloodPressureDao.getAllBloodPressureEntries() } returns flowOf(emptyList())
+        every { cholesterolDao.getAllCholesterolEntries() } returns flowOf(emptyList())
+        every { weightDao.getAllWeightEntries() } returns flowOf(emptyList())
 
         repository = LogRepository(
             mealDao,
             symptomEntryDao,
             bowelMovementDao,
             medicationDao,
-            otherEntryDao
+            otherEntryDao,
+            bloodPressureDao,
+            cholesterolDao,
+            weightDao
         )
     }
 

--- a/app/src/test/java/com/foodsymptomlog/util/TestData.kt
+++ b/app/src/test/java/com/foodsymptomlog/util/TestData.kt
@@ -1,6 +1,8 @@
 package com.foodsymptomlog.util
 
+import com.foodsymptomlog.data.entity.BloodPressureEntry
 import com.foodsymptomlog.data.entity.BowelMovementEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
 import com.foodsymptomlog.data.entity.FoodItem
 import com.foodsymptomlog.data.entity.MealEntry
 import com.foodsymptomlog.data.entity.MealType
@@ -10,6 +12,8 @@ import com.foodsymptomlog.data.entity.OtherEntry
 import com.foodsymptomlog.data.entity.OtherEntryType
 import com.foodsymptomlog.data.entity.SymptomEntry
 import com.foodsymptomlog.data.entity.Tag
+import com.foodsymptomlog.data.entity.WeightEntry
+import com.foodsymptomlog.data.entity.WeightUnit
 
 object TestData {
 
@@ -107,6 +111,54 @@ object TestData {
         entryType = entryType,
         subType = subType,
         value = value,
+        notes = notes,
+        timestamp = timestamp
+    )
+
+    fun createBloodPressureEntry(
+        id: Long = 1L,
+        systolic: Int = 120,
+        diastolic: Int = 80,
+        pulse: Int? = 72,
+        notes: String = "Test notes",
+        timestamp: Long = 1000L
+    ) = BloodPressureEntry(
+        id = id,
+        systolic = systolic,
+        diastolic = diastolic,
+        pulse = pulse,
+        notes = notes,
+        timestamp = timestamp
+    )
+
+    fun createCholesterolEntry(
+        id: Long = 1L,
+        total: Int? = 200,
+        ldl: Int? = 100,
+        hdl: Int? = 60,
+        triglycerides: Int? = 150,
+        notes: String = "Test notes",
+        timestamp: Long = 1000L
+    ) = CholesterolEntry(
+        id = id,
+        total = total,
+        ldl = ldl,
+        hdl = hdl,
+        triglycerides = triglycerides,
+        notes = notes,
+        timestamp = timestamp
+    )
+
+    fun createWeightEntry(
+        id: Long = 1L,
+        weight: Double = 150.0,
+        unit: WeightUnit = WeightUnit.LB,
+        notes: String = "Test notes",
+        timestamp: Long = 1000L
+    ) = WeightEntry(
+        id = id,
+        weight = weight,
+        unit = unit,
         notes = notes,
         timestamp = timestamp
     )


### PR DESCRIPTION
Add three new biometric entry types: Blood Pressure, Cholesterol, and Weight with full CRUD support. Reorganize home screen with category dropdowns for Biometrics and Other entries while making Meal, Symptom, and Medication buttons navigate directly to their add screens.