### PR TITLE
feat: add biometrics charts with time-proportional x-axis spacing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,9 @@ dependencies {
     implementation("androidx.room:room-ktx:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")
 
+    // Charting - Vico
+    implementation("com.patrykandpatrick.vico:compose-m3:1.15.0")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")

--- a/app/src/main/java/com/foodsymptomlog/MainActivity.kt
+++ b/app/src/main/java/com/foodsymptomlog/MainActivity.kt
@@ -20,6 +20,7 @@ import com.foodsymptomlog.ui.screens.AddMedicationScreen
 import com.foodsymptomlog.ui.screens.AddOtherEntryScreen
 import com.foodsymptomlog.ui.screens.AddSymptomScreen
 import com.foodsymptomlog.ui.screens.AddWeightScreen
+import com.foodsymptomlog.ui.screens.BiometricsChartScreen
 import com.foodsymptomlog.ui.screens.CalendarScreen
 import com.foodsymptomlog.ui.screens.HistoryScreen
 import com.foodsymptomlog.ui.screens.HomeScreen
@@ -59,6 +60,7 @@ class MainActivity : ComponentActivity() {
                                 onAddBloodPressure = { navController.navigate("add_blood_pressure") },
                                 onAddCholesterol = { navController.navigate("add_cholesterol") },
                                 onAddWeight = { navController.navigate("add_weight") },
+                                onViewBiometricsChart = { navController.navigate("biometrics_chart") },
                                 onViewHistory = { navController.navigate("history") },
                                 onViewCalendar = { navController.navigate("calendar") },
                                 onViewSettings = { navController.navigate("settings") },
@@ -151,6 +153,12 @@ class MainActivity : ComponentActivity() {
                         }
                         composable("settings") {
                             SettingsScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() }
+                            )
+                        }
+                        composable("biometrics_chart") {
+                            BiometricsChartScreen(
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() }
                             )

--- a/app/src/main/java/com/foodsymptomlog/ui/components/BiometricsCharts.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/components/BiometricsCharts.kt
@@ -1,0 +1,482 @@
+package com.foodsymptomlog.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ShowChart
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.data.entity.BloodPressureEntry
+import com.foodsymptomlog.data.entity.CholesterolEntry
+import com.foodsymptomlog.data.entity.WeightEntry
+import com.foodsymptomlog.data.entity.WeightUnit
+import com.patrykandpatrick.vico.compose.axis.horizontal.rememberBottomAxis
+import com.patrykandpatrick.vico.compose.axis.vertical.rememberStartAxis
+import com.patrykandpatrick.vico.compose.chart.Chart
+import com.patrykandpatrick.vico.compose.chart.line.lineChart
+import com.patrykandpatrick.vico.compose.component.shape.shader.fromBrush
+import com.patrykandpatrick.vico.compose.style.ProvideChartStyle
+import com.patrykandpatrick.vico.core.chart.line.LineChart
+import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShaders
+import com.patrykandpatrick.vico.core.axis.AxisPosition
+import com.patrykandpatrick.vico.core.axis.AxisItemPlacer
+import com.patrykandpatrick.vico.core.axis.formatter.AxisValueFormatter
+import com.patrykandpatrick.vico.compose.component.textComponent
+import androidx.compose.ui.unit.sp
+import android.graphics.Typeface
+import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
+import com.patrykandpatrick.vico.core.entry.entryOf
+import com.foodsymptomlog.ui.utils.formatDateForAxis
+
+@Composable
+fun EmptyChartState(message: String = "No data available") {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.ShowChart,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+            )
+        }
+    }
+}
+
+@Composable
+fun WeightChart(
+    entries: List<WeightEntry>,
+    modifier: Modifier = Modifier
+) {
+    if (entries.isEmpty()) {
+        EmptyChartState("No weight data to display")
+        return
+    }
+
+    val sortedEntries = remember(entries) { entries.sortedBy { it.timestamp } }
+    val chartColor = MaterialTheme.colorScheme.primary
+    val unit = sortedEntries.lastOrNull()?.unit ?: WeightUnit.LB
+
+    val minTimestamp = remember(sortedEntries) { sortedEntries.minOf { it.timestamp } }
+    val msPerDay = 24 * 60 * 60 * 1000L
+
+    val chartEntryModelProducer = remember(sortedEntries) {
+        ChartEntryModelProducer(
+            sortedEntries.map { entry ->
+                val dayOffset = ((entry.timestamp - minTimestamp) / msPerDay).toFloat()
+                entryOf(dayOffset, entry.weight.toFloat())
+            }
+        )
+    }
+
+    val lineSpec = remember(chartColor) {
+        listOf(
+            LineChart.LineSpec(
+                lineColor = chartColor.toArgb(),
+                lineBackgroundShader = DynamicShaders.fromBrush(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            chartColor.copy(alpha = 0.4f),
+                            chartColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    val bottomAxisFormatter = remember(sortedEntries, minTimestamp) {
+        AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+            val timestamp = minTimestamp + (value * msPerDay).toLong()
+            formatDateForAxis(timestamp)
+        }
+    }
+
+    val startAxisFormatter = remember(unit) {
+        AxisValueFormatter<AxisPosition.Vertical.Start> { value, _ ->
+            "%.0f %s".format(value, unit.name.lowercase())
+        }
+    }
+
+    val axisLabelComponent = textComponent(
+        color = MaterialTheme.colorScheme.onSurface,
+        textSize = 9.sp,
+        typeface = Typeface.DEFAULT
+    )
+
+    Chart(
+        chart = lineChart(lines = lineSpec),
+        chartModelProducer = chartEntryModelProducer,
+        startAxis = rememberStartAxis(valueFormatter = startAxisFormatter),
+        bottomAxis = rememberBottomAxis(
+            label = axisLabelComponent,
+            valueFormatter = bottomAxisFormatter,
+            tickLength = 4.dp,
+            itemPlacer = AxisItemPlacer.Horizontal.default(spacing = 3)
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(200.dp)
+    )
+}
+
+@Composable
+fun BloodPressureChart(
+    entries: List<BloodPressureEntry>,
+    modifier: Modifier = Modifier
+) {
+    if (entries.isEmpty()) {
+        EmptyChartState("No blood pressure data to display")
+        return
+    }
+
+    val sortedEntries = remember(entries) { entries.sortedBy { it.timestamp } }
+    val systolicColor = MaterialTheme.colorScheme.error
+    val diastolicColor = MaterialTheme.colorScheme.tertiary
+
+    val minTimestamp = remember(sortedEntries) { sortedEntries.minOf { it.timestamp } }
+    val msPerDay = 24 * 60 * 60 * 1000L
+
+    val chartEntryModelProducer = remember(sortedEntries) {
+        ChartEntryModelProducer(
+            sortedEntries.map { entry ->
+                val dayOffset = ((entry.timestamp - minTimestamp) / msPerDay).toFloat()
+                entryOf(dayOffset, entry.systolic.toFloat())
+            },
+            sortedEntries.map { entry ->
+                val dayOffset = ((entry.timestamp - minTimestamp) / msPerDay).toFloat()
+                entryOf(dayOffset, entry.diastolic.toFloat())
+            }
+        )
+    }
+
+    val lineSpec = remember(systolicColor, diastolicColor) {
+        listOf(
+            LineChart.LineSpec(
+                lineColor = systolicColor.toArgb(),
+                lineBackgroundShader = DynamicShaders.fromBrush(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            systolicColor.copy(alpha = 0.2f),
+                            systolicColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+            ),
+            LineChart.LineSpec(
+                lineColor = diastolicColor.toArgb(),
+                lineBackgroundShader = DynamicShaders.fromBrush(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            diastolicColor.copy(alpha = 0.2f),
+                            diastolicColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    val bottomAxisFormatter = remember(sortedEntries, minTimestamp) {
+        AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+            val timestamp = minTimestamp + (value * msPerDay).toLong()
+            formatDateForAxis(timestamp)
+        }
+    }
+
+    val startAxisFormatter = remember {
+        AxisValueFormatter<AxisPosition.Vertical.Start> { value, _ ->
+            "%.0f".format(value)
+        }
+    }
+
+    val axisLabelComponent = textComponent(
+        color = MaterialTheme.colorScheme.onSurface,
+        textSize = 9.sp,
+        typeface = Typeface.DEFAULT
+    )
+
+    Column(modifier = modifier) {
+        Chart(
+            chart = lineChart(lines = lineSpec),
+            chartModelProducer = chartEntryModelProducer,
+            startAxis = rememberStartAxis(valueFormatter = startAxisFormatter),
+            bottomAxis = rememberBottomAxis(
+                label = axisLabelComponent,
+                valueFormatter = bottomAxisFormatter,
+                tickLength = 4.dp,
+                itemPlacer = AxisItemPlacer.Horizontal.default(spacing = 3)
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Legend with unit
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            LegendItem(color = systolicColor, label = "Systolic")
+            Spacer(modifier = Modifier.width(24.dp))
+            LegendItem(color = diastolicColor, label = "Diastolic")
+            Spacer(modifier = Modifier.width(24.dp))
+            Text(
+                text = "(mmHg)",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun CholesterolChart(
+    entries: List<CholesterolEntry>,
+    modifier: Modifier = Modifier
+) {
+    val entriesWithTotal = remember(entries) {
+        entries.filter { it.total != null }.sortedBy { it.timestamp }
+    }
+
+    if (entriesWithTotal.isEmpty()) {
+        EmptyChartState("No cholesterol data to display")
+        return
+    }
+
+    val chartColor = MaterialTheme.colorScheme.secondary
+
+    val minTimestamp = remember(entriesWithTotal) { entriesWithTotal.minOf { it.timestamp } }
+    val msPerDay = 24 * 60 * 60 * 1000L
+
+    val chartEntryModelProducer = remember(entriesWithTotal) {
+        ChartEntryModelProducer(
+            entriesWithTotal.map { entry ->
+                val dayOffset = ((entry.timestamp - minTimestamp) / msPerDay).toFloat()
+                entryOf(dayOffset, entry.total!!.toFloat())
+            }
+        )
+    }
+
+    val lineSpec = remember(chartColor) {
+        listOf(
+            LineChart.LineSpec(
+                lineColor = chartColor.toArgb(),
+                lineBackgroundShader = DynamicShaders.fromBrush(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            chartColor.copy(alpha = 0.4f),
+                            chartColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    val bottomAxisFormatter = remember(entriesWithTotal, minTimestamp) {
+        AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+            val timestamp = minTimestamp + (value * msPerDay).toLong()
+            formatDateForAxis(timestamp)
+        }
+    }
+
+    val startAxisFormatter = remember {
+        AxisValueFormatter<AxisPosition.Vertical.Start> { value, _ ->
+            "%.0f".format(value)
+        }
+    }
+
+    val axisLabelComponent = textComponent(
+        color = MaterialTheme.colorScheme.onSurface,
+        textSize = 9.sp,
+        typeface = Typeface.DEFAULT
+    )
+
+    Column(modifier = modifier) {
+        Chart(
+            chart = lineChart(lines = lineSpec),
+            chartModelProducer = chartEntryModelProducer,
+            startAxis = rememberStartAxis(valueFormatter = startAxisFormatter),
+            bottomAxis = rememberBottomAxis(
+                label = axisLabelComponent,
+                valueFormatter = bottomAxisFormatter,
+                tickLength = 4.dp,
+                itemPlacer = AxisItemPlacer.Horizontal.default(spacing = 3)
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Unit label
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "mg/dL",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .padding(2.dp)
+        ) {
+            androidx.compose.foundation.Canvas(modifier = Modifier.size(12.dp)) {
+                drawCircle(color = color)
+            }
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+@Composable
+fun WeightSummaryCard(entries: List<WeightEntry>) {
+    if (entries.isEmpty()) return
+
+    val latest = entries.maxByOrNull { it.timestamp }
+    val min = entries.minByOrNull { it.weight }
+    val max = entries.maxByOrNull { it.weight }
+    val avg = entries.map { it.weight }.average()
+    val unit = latest?.unit ?: WeightUnit.LB
+
+    SummaryCard(
+        title = "Weight Summary",
+        items = listOf(
+            SummaryItem("Latest", latest?.let { "%.1f ${unit.name.lowercase()}".format(it.weight) } ?: "-"),
+            SummaryItem("Min", min?.let { "%.1f".format(it.weight) } ?: "-"),
+            SummaryItem("Max", max?.let { "%.1f".format(it.weight) } ?: "-"),
+            SummaryItem("Avg", "%.1f".format(avg))
+        )
+    )
+}
+
+@Composable
+fun BloodPressureSummaryCard(entries: List<BloodPressureEntry>) {
+    if (entries.isEmpty()) return
+
+    val latest = entries.maxByOrNull { it.timestamp }
+    val avgSystolic = entries.map { it.systolic }.average()
+    val avgDiastolic = entries.map { it.diastolic }.average()
+
+    SummaryCard(
+        title = "Blood Pressure Summary",
+        items = listOf(
+            SummaryItem("Latest", latest?.let { "${it.systolic}/${it.diastolic}" } ?: "-"),
+            SummaryItem("Avg Sys", "%.0f".format(avgSystolic)),
+            SummaryItem("Avg Dia", "%.0f".format(avgDiastolic)),
+            SummaryItem("Count", "${entries.size}")
+        )
+    )
+}
+
+@Composable
+fun CholesterolSummaryCard(entries: List<CholesterolEntry>) {
+    val entriesWithTotal = entries.filter { it.total != null }
+    if (entriesWithTotal.isEmpty()) return
+
+    val latest = entriesWithTotal.maxByOrNull { it.timestamp }
+    val min = entriesWithTotal.minByOrNull { it.total!! }
+    val max = entriesWithTotal.maxByOrNull { it.total!! }
+    val avg = entriesWithTotal.mapNotNull { it.total }.average()
+
+    SummaryCard(
+        title = "Cholesterol Summary",
+        items = listOf(
+            SummaryItem("Latest", latest?.total?.toString() ?: "-"),
+            SummaryItem("Min", min?.total?.toString() ?: "-"),
+            SummaryItem("Max", max?.total?.toString() ?: "-"),
+            SummaryItem("Avg", "%.0f".format(avg))
+        )
+    )
+}
+
+private data class SummaryItem(val label: String, val value: String)
+
+@Composable
+private fun SummaryCard(title: String, items: List<SummaryItem>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                items.forEach { item ->
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = item.value,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = item.label,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/BiometricsChartScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/BiometricsChartScreen.kt
@@ -1,0 +1,163 @@
+package com.foodsymptomlog.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.foodsymptomlog.ui.components.BloodPressureChart
+import com.foodsymptomlog.ui.components.BloodPressureSummaryCard
+import com.foodsymptomlog.ui.components.CholesterolChart
+import com.foodsymptomlog.ui.components.CholesterolSummaryCard
+import com.foodsymptomlog.ui.components.WeightChart
+import com.foodsymptomlog.ui.components.WeightSummaryCard
+import com.foodsymptomlog.ui.utils.TimeRange
+import com.foodsymptomlog.ui.utils.filterByTimeRange
+import com.foodsymptomlog.viewmodel.LogViewModel
+
+enum class BiometricTab(val title: String) {
+    WEIGHT("Weight"),
+    BLOOD_PRESSURE("Blood Pressure"),
+    CHOLESTEROL("Cholesterol")
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun BiometricsChartScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit
+) {
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var selectedTimeRange by remember { mutableStateOf(TimeRange.THIRTY_DAYS) }
+
+    val allWeightEntries by viewModel.allWeightEntries.collectAsState()
+    val allBloodPressureEntries by viewModel.allBloodPressureEntries.collectAsState()
+    val allCholesterolEntries by viewModel.allCholesterolEntries.collectAsState()
+
+    val filteredWeightEntries = remember(allWeightEntries, selectedTimeRange) {
+        filterByTimeRange(allWeightEntries, selectedTimeRange) { it.timestamp }
+    }
+
+    val filteredBloodPressureEntries = remember(allBloodPressureEntries, selectedTimeRange) {
+        filterByTimeRange(allBloodPressureEntries, selectedTimeRange) { it.timestamp }
+    }
+
+    val filteredCholesterolEntries = remember(allCholesterolEntries, selectedTimeRange) {
+        filterByTimeRange(allCholesterolEntries, selectedTimeRange) { it.timestamp }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Biometrics Charts",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Tab Row
+            ScrollableTabRow(
+                selectedTabIndex = selectedTab,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BiometricTab.entries.forEachIndexed { index, tab ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(tab.title) }
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Time Range Filter Chips
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    TimeRange.entries.forEach { range ->
+                        FilterChip(
+                            selected = selectedTimeRange == range,
+                            onClick = { selectedTimeRange = range },
+                            label = { Text(range.label) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Chart Content
+                when (BiometricTab.entries[selectedTab]) {
+                    BiometricTab.WEIGHT -> {
+                        WeightChart(entries = filteredWeightEntries)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        WeightSummaryCard(entries = filteredWeightEntries)
+                    }
+                    BiometricTab.BLOOD_PRESSURE -> {
+                        BloodPressureChart(entries = filteredBloodPressureEntries)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        BloodPressureSummaryCard(entries = filteredBloodPressureEntries)
+                    }
+                    BiometricTab.CHOLESTEROL -> {
+                        CholesterolChart(entries = filteredCholesterolEntries)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        CholesterolSummaryCard(entries = filteredCholesterolEntries)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/foodsymptomlog/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/screens/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -78,6 +79,7 @@ fun HomeScreen(
     onAddBloodPressure: () -> Unit,
     onAddCholesterol: () -> Unit,
     onAddWeight: () -> Unit,
+    onViewBiometricsChart: () -> Unit = {},
     onViewHistory: () -> Unit,
     onViewCalendar: () -> Unit = {},
     onViewSettings: () -> Unit = {},
@@ -250,6 +252,20 @@ fun HomeScreen(
                             onClick = {
                                 biometricsMenuExpanded = false
                                 onAddWeight()
+                            }
+                        )
+                        Divider()
+                        DropdownMenuItem(
+                            text = { Text("View Charts") },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Default.ShowChart,
+                                    contentDescription = null
+                                )
+                            },
+                            onClick = {
+                                biometricsMenuExpanded = false
+                                onViewBiometricsChart()
                             }
                         )
                     }

--- a/app/src/main/java/com/foodsymptomlog/ui/utils/ChartUtils.kt
+++ b/app/src/main/java/com/foodsymptomlog/ui/utils/ChartUtils.kt
@@ -1,0 +1,42 @@
+package com.foodsymptomlog.ui.utils
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+enum class TimeRange(val label: String, val days: Int?) {
+    SEVEN_DAYS("7 Days", 7),
+    THIRTY_DAYS("30 Days", 30),
+    NINETY_DAYS("90 Days", 90),
+    ALL_TIME("All Time", null)
+}
+
+fun <T> filterByTimeRange(
+    entries: List<T>,
+    timeRange: TimeRange,
+    timestampSelector: (T) -> Long
+): List<T> {
+    if (timeRange.days == null) return entries
+
+    val cutoff = System.currentTimeMillis() - (timeRange.days * 24 * 60 * 60 * 1000L)
+    return entries.filter { timestampSelector(it) >= cutoff }
+}
+
+fun formatDateForAxis(timestamp: Long, compact: Boolean = true): String {
+    val date = Instant.ofEpochMilli(timestamp)
+        .atZone(ZoneId.systemDefault())
+        .toLocalDate()
+
+    return if (compact) {
+        date.format(DateTimeFormatter.ofPattern("M/d/yy"))
+    } else {
+        date.format(DateTimeFormatter.ofPattern("MMM d, yyyy"))
+    }
+}
+
+fun formatDateTimeForTooltip(timestamp: Long): String {
+    val dateTime = Instant.ofEpochMilli(timestamp)
+        .atZone(ZoneId.systemDefault())
+    return dateTime.format(DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a"))
+}


### PR DESCRIPTION
Add interactive charts for weight, blood pressure, and cholesterol data with proper time-based x-axis spacing. Charts display data points proportionally based on actual timestamps rather than equal intervals.

- Add Vico charting library dependency
- Create BiometricsCharts component with WeightChart, BloodPressureChart, and CholesterolChart
- Add BiometricsChartScreen with time range filtering
- Add chart utilities for date formatting and time range filtering
- Add navigation to charts from biometrics menu