### PR TITLE
feat: add scheduled reminders for medication sets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -21,6 +25,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name=".notification.ReminderBroadcastReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -11,6 +11,8 @@ import com.privatehealthjournal.data.dao.CholesterolDao
 import com.privatehealthjournal.data.dao.MealDao
 import com.privatehealthjournal.data.dao.MedicationDao
 import com.privatehealthjournal.data.dao.MedicationSetDao
+import com.privatehealthjournal.data.dao.MedicationSetLogDao
+import com.privatehealthjournal.data.dao.MedicationSetReminderDao
 import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.SpO2Dao
 import com.privatehealthjournal.data.dao.SymptomEntryDao
@@ -25,6 +27,8 @@ import com.privatehealthjournal.data.entity.MealTagCrossRef
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.MedicationSet
 import com.privatehealthjournal.data.entity.MedicationSetItem
+import com.privatehealthjournal.data.entity.MedicationSetLog
+import com.privatehealthjournal.data.entity.MedicationSetReminder
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
 import com.privatehealthjournal.data.entity.SymptomEntry
@@ -47,9 +51,11 @@ import com.privatehealthjournal.data.entity.WeightEntry
         SpO2Entry::class,
         BloodGlucoseEntry::class,
         MedicationSet::class,
-        MedicationSetItem::class
+        MedicationSetItem::class,
+        MedicationSetReminder::class,
+        MedicationSetLog::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -64,6 +70,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun spO2Dao(): SpO2Dao
     abstract fun bloodGlucoseDao(): BloodGlucoseDao
     abstract fun medicationSetDao(): MedicationSetDao
+    abstract fun medicationSetReminderDao(): MedicationSetReminderDao
+    abstract fun medicationSetLogDao(): MedicationSetLogDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/privatehealthjournal/data/dao/MedicationSetLogDao.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/dao/MedicationSetLogDao.kt
@@ -1,0 +1,15 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.privatehealthjournal.data.entity.MedicationSetLog
+
+@Dao
+interface MedicationSetLogDao {
+    @Insert
+    suspend fun insert(log: MedicationSetLog): Long
+
+    @Query("SELECT * FROM medication_set_logs WHERE setId = :setId AND timestamp >= :startOfDay AND timestamp < :endOfDay LIMIT 1")
+    suspend fun getLogForSetOnDay(setId: Long, startOfDay: Long, endOfDay: Long): MedicationSetLog?
+}

--- a/app/src/main/java/com/privatehealthjournal/data/dao/MedicationSetReminderDao.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/dao/MedicationSetReminderDao.kt
@@ -1,0 +1,36 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.privatehealthjournal.data.entity.MedicationSetReminder
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MedicationSetReminderDao {
+    @Query("SELECT * FROM medication_set_reminders WHERE setId = :setId ORDER BY hour, minute")
+    fun getRemindersForSet(setId: Long): Flow<List<MedicationSetReminder>>
+
+    @Query("SELECT * FROM medication_set_reminders ORDER BY hour, minute")
+    fun getAllReminders(): Flow<List<MedicationSetReminder>>
+
+    @Query("SELECT * FROM medication_set_reminders WHERE enabled = 1")
+    suspend fun getAllEnabledReminders(): List<MedicationSetReminder>
+
+    @Query("SELECT * FROM medication_set_reminders WHERE id = :id")
+    suspend fun getById(id: Long): MedicationSetReminder?
+
+    @Insert
+    suspend fun insert(reminder: MedicationSetReminder): Long
+
+    @Update
+    suspend fun update(reminder: MedicationSetReminder)
+
+    @Delete
+    suspend fun delete(reminder: MedicationSetReminder)
+
+    @Query("DELETE FROM medication_set_reminders WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetLog.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetLog.kt
@@ -1,0 +1,25 @@
+package com.privatehealthjournal.data.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "medication_set_logs",
+    foreignKeys = [
+        ForeignKey(
+            entity = MedicationSet::class,
+            parentColumns = ["id"],
+            childColumns = ["setId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("setId")]
+)
+data class MedicationSetLog(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val setId: Long,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetReminder.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetReminder.kt
@@ -1,0 +1,69 @@
+package com.privatehealthjournal.data.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.Calendar
+
+@Entity(
+    tableName = "medication_set_reminders",
+    foreignKeys = [
+        ForeignKey(
+            entity = MedicationSet::class,
+            parentColumns = ["id"],
+            childColumns = ["setId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("setId")]
+)
+data class MedicationSetReminder(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val setId: Long,
+    val hour: Int,
+    val minute: Int,
+    val daysOfWeek: Int = DaysOfWeek.EVERY_DAY,
+    val enabled: Boolean = true
+)
+
+object DaysOfWeek {
+    const val MONDAY = 1
+    const val TUESDAY = 2
+    const val WEDNESDAY = 4
+    const val THURSDAY = 8
+    const val FRIDAY = 16
+    const val SATURDAY = 32
+    const val SUNDAY = 64
+    const val EVERY_DAY = 127
+
+    private val ALL_DAYS = listOf(
+        MONDAY to "Mon",
+        TUESDAY to "Tue",
+        WEDNESDAY to "Wed",
+        THURSDAY to "Thu",
+        FRIDAY to "Fri",
+        SATURDAY to "Sat",
+        SUNDAY to "Sun"
+    )
+
+    fun isDayEnabled(bitmask: Int, day: Int): Boolean = bitmask and day != 0
+
+    fun toDisplayString(bitmask: Int): String {
+        if (bitmask == EVERY_DAY) return "Every day"
+        val days = ALL_DAYS.filter { isDayEnabled(bitmask, it.first) }.map { it.second }
+        return days.joinToString(", ")
+    }
+
+    fun fromCalendarDayOfWeek(calendarDay: Int): Int = when (calendarDay) {
+        Calendar.MONDAY -> MONDAY
+        Calendar.TUESDAY -> TUESDAY
+        Calendar.WEDNESDAY -> WEDNESDAY
+        Calendar.THURSDAY -> THURSDAY
+        Calendar.FRIDAY -> FRIDAY
+        Calendar.SATURDAY -> SATURDAY
+        Calendar.SUNDAY -> SUNDAY
+        else -> 0
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/notification/ReminderBroadcastReceiver.kt
+++ b/app/src/main/java/com/privatehealthjournal/notification/ReminderBroadcastReceiver.kt
@@ -1,0 +1,99 @@
+package com.privatehealthjournal.notification
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.privatehealthjournal.MainActivity
+import com.privatehealthjournal.R
+import com.privatehealthjournal.data.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Calendar
+
+class ReminderBroadcastReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val CHANNEL_ID = "medication_reminders"
+        private const val EXTRA_REMINDER_ID = "reminder_id"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            val pendingResult = goAsync()
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    ReminderScheduler.rescheduleAllReminders(context)
+                } finally {
+                    pendingResult.finish()
+                }
+            }
+            return
+        }
+
+        val reminderId = intent.getLongExtra(EXTRA_REMINDER_ID, -1L)
+        if (reminderId == -1L) return
+
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val db = AppDatabase.getDatabase(context)
+                val reminder = db.medicationSetReminderDao().getById(reminderId) ?: return@launch
+
+                // Reschedule for next occurrence
+                if (reminder.enabled) {
+                    ReminderScheduler.scheduleReminder(context, reminder)
+                }
+
+                // Check if set was already logged today
+                val calendar = Calendar.getInstance()
+                calendar.set(Calendar.HOUR_OF_DAY, 0)
+                calendar.set(Calendar.MINUTE, 0)
+                calendar.set(Calendar.SECOND, 0)
+                calendar.set(Calendar.MILLISECOND, 0)
+                val startOfDay = calendar.timeInMillis
+                val endOfDay = startOfDay + 86_400_000L
+
+                val alreadyLogged = db.medicationSetLogDao()
+                    .getLogForSetOnDay(reminder.setId, startOfDay, endOfDay) != null
+
+                if (!alreadyLogged) {
+                    val set = db.medicationSetDao().getSetWithItemsById(reminder.setId)
+                    val setName = set?.set?.name ?: "Medication Set"
+                    showNotification(context, reminder.setId, setName)
+                }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun showNotification(context: Context, setId: Long, setName: String) {
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("navigate_to", "medication_sets")
+        }
+        val pendingTapIntent = PendingIntent.getActivity(
+            context,
+            setId.toInt(),
+            tapIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Time to log: $setName")
+            .setContentText("Tap to open medication sets and log your medications")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingTapIntent)
+            .build()
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(setId.toInt(), notification)
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/notification/ReminderScheduler.kt
+++ b/app/src/main/java/com/privatehealthjournal/notification/ReminderScheduler.kt
@@ -1,0 +1,97 @@
+package com.privatehealthjournal.notification
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.privatehealthjournal.data.AppDatabase
+import com.privatehealthjournal.data.entity.DaysOfWeek
+import com.privatehealthjournal.data.entity.MedicationSetReminder
+import java.util.Calendar
+
+object ReminderScheduler {
+
+    private const val ACTION_REMINDER = "com.privatehealthjournal.MEDICATION_REMINDER"
+    private const val EXTRA_REMINDER_ID = "reminder_id"
+
+    fun scheduleReminder(context: Context, reminder: MedicationSetReminder) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, ReminderBroadcastReceiver::class.java).apply {
+            action = ACTION_REMINDER
+            putExtra(EXTRA_REMINDER_ID, reminder.id)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            reminder.id.toInt(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val triggerTime = computeNextTriggerTime(reminder)
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerTime,
+            pendingIntent
+        )
+    }
+
+    fun cancelReminder(context: Context, reminderId: Long) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, ReminderBroadcastReceiver::class.java).apply {
+            action = ACTION_REMINDER
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            reminderId.toInt(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.cancel(pendingIntent)
+    }
+
+    suspend fun rescheduleAllReminders(context: Context) {
+        val db = AppDatabase.getDatabase(context)
+        val reminders = db.medicationSetReminderDao().getAllEnabledReminders()
+        reminders.forEach { reminder ->
+            scheduleReminder(context, reminder)
+        }
+    }
+
+    fun dismissNotification(context: Context, setId: Long) {
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancel(setId.toInt())
+    }
+
+    fun computeNextTriggerTime(reminder: MedicationSetReminder): Long {
+        val now = Calendar.getInstance()
+        val candidate = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, reminder.hour)
+            set(Calendar.MINUTE, reminder.minute)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        // Try up to 8 days to find the next matching day
+        for (i in 0..7) {
+            if (i > 0) {
+                candidate.add(Calendar.DAY_OF_YEAR, 1)
+            }
+            val dayOfWeek = DaysOfWeek.fromCalendarDayOfWeek(candidate.get(Calendar.DAY_OF_WEEK))
+            if (DaysOfWeek.isDayEnabled(reminder.daysOfWeek, dayOfWeek)) {
+                if (candidate.after(now)) {
+                    return candidate.timeInMillis
+                }
+            }
+        }
+        // Fallback: schedule for tomorrow at the specified time
+        candidate.timeInMillis = now.timeInMillis
+        candidate.add(Calendar.DAY_OF_YEAR, 1)
+        candidate.set(Calendar.HOUR_OF_DAY, reminder.hour)
+        candidate.set(Calendar.MINUTE, reminder.minute)
+        candidate.set(Calendar.SECOND, 0)
+        candidate.set(Calendar.MILLISECOND, 0)
+        return candidate.timeInMillis
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/components/ReminderEditDialog.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/ReminderEditDialog.kt
@@ -1,0 +1,124 @@
+package com.privatehealthjournal.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.DaysOfWeek
+import com.privatehealthjournal.data.entity.MedicationSetReminder
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ReminderEditDialog(
+    existingReminder: MedicationSetReminder? = null,
+    setId: Long,
+    onSave: (MedicationSetReminder) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val timePickerState = rememberTimePickerState(
+        initialHour = existingReminder?.hour ?: 8,
+        initialMinute = existingReminder?.minute ?: 0,
+        is24Hour = false
+    )
+    var selectedDays by remember {
+        mutableIntStateOf(existingReminder?.daysOfWeek ?: DaysOfWeek.EVERY_DAY)
+    }
+
+    val dayOptions = listOf(
+        DaysOfWeek.MONDAY to "Mon",
+        DaysOfWeek.TUESDAY to "Tue",
+        DaysOfWeek.WEDNESDAY to "Wed",
+        DaysOfWeek.THURSDAY to "Thu",
+        DaysOfWeek.FRIDAY to "Fri",
+        DaysOfWeek.SATURDAY to "Sat",
+        DaysOfWeek.SUNDAY to "Sun"
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(if (existingReminder != null) "Edit Reminder" else "Add Reminder")
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                TimePicker(state = timePickerState)
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "Repeat on",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    dayOptions.forEach { (dayBit, label) ->
+                        val isSelected = DaysOfWeek.isDayEnabled(selectedDays, dayBit)
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = {
+                                selectedDays = if (isSelected) {
+                                    selectedDays and dayBit.inv()
+                                } else {
+                                    selectedDays or dayBit
+                                }
+                            },
+                            label = { Text(label) }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (selectedDays == 0) return@TextButton
+                    val reminder = MedicationSetReminder(
+                        id = existingReminder?.id ?: 0,
+                        setId = setId,
+                        hour = timePickerState.hour,
+                        minute = timePickerState.minute,
+                        daysOfWeek = selectedDays,
+                        enabled = existingReminder?.enabled ?: true
+                    )
+                    onSave(reminder)
+                }
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -24,6 +25,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -32,18 +34,25 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.DaysOfWeek
+import com.privatehealthjournal.data.entity.MedicationSetReminder
 import com.privatehealthjournal.data.entity.MedicationSetWithItems
+import com.privatehealthjournal.ui.components.ReminderEditDialog
 import com.privatehealthjournal.viewmodel.LogViewModel
 import kotlinx.coroutines.launch
 
@@ -56,6 +65,7 @@ fun MedicationSetsScreen(
     onEditSet: (Long) -> Unit
 ) {
     val medicationSets by viewModel.allMedicationSets.collectAsState()
+    val remindersBySet by viewModel.allRemindersBySet.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -129,6 +139,7 @@ fun MedicationSetsScreen(
                 items(medicationSets, key = { it.set.id }) { setWithItems ->
                     MedicationSetCard(
                         setWithItems = setWithItems,
+                        reminders = remindersBySet[setWithItems.set.id] ?: emptyList(),
                         onLogAll = {
                             viewModel.logMedicationSet(setWithItems)
                             scope.launch {
@@ -138,7 +149,10 @@ fun MedicationSetsScreen(
                             }
                         },
                         onEdit = { onEditSet(setWithItems.set.id) },
-                        onDelete = { viewModel.deleteMedicationSet(setWithItems.set.id) }
+                        onDelete = { viewModel.deleteMedicationSet(setWithItems.set.id) },
+                        onAddReminder = { reminder -> viewModel.addReminder(reminder) },
+                        onUpdateReminder = { reminder -> viewModel.updateReminder(reminder) },
+                        onDeleteReminder = { reminder -> viewModel.deleteReminder(reminder) }
                     )
                 }
             }
@@ -149,10 +163,17 @@ fun MedicationSetsScreen(
 @Composable
 private fun MedicationSetCard(
     setWithItems: MedicationSetWithItems,
+    reminders: List<MedicationSetReminder>,
     onLogAll: () -> Unit,
     onEdit: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onAddReminder: (MedicationSetReminder) -> Unit,
+    onUpdateReminder: (MedicationSetReminder) -> Unit,
+    onDeleteReminder: (MedicationSetReminder) -> Unit
 ) {
+    var showAddReminderDialog by remember { mutableStateOf(false) }
+    var editingReminder by remember { mutableStateOf<MedicationSetReminder?>(null) }
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -218,7 +239,39 @@ private fun MedicationSetCard(
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            // Reminders section
+            if (reminders.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Divider(color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.2f))
+                Spacer(modifier = Modifier.height(8.dp))
+
+                reminders.forEach { reminder ->
+                    ReminderRow(
+                        reminder = reminder,
+                        onToggle = { enabled ->
+                            onUpdateReminder(reminder.copy(enabled = enabled))
+                        },
+                        onEdit = { editingReminder = reminder },
+                        onDelete = { onDeleteReminder(reminder) }
+                    )
+                }
+            }
+
+            // Add Reminder button
+            TextButton(
+                onClick = { showAddReminderDialog = true },
+                modifier = Modifier.padding(start = 28.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Alarm,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Add Reminder")
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
 
             Button(
                 onClick = onLogAll,
@@ -237,4 +290,92 @@ private fun MedicationSetCard(
             }
         }
     }
+
+    if (showAddReminderDialog) {
+        ReminderEditDialog(
+            setId = setWithItems.set.id,
+            onSave = { reminder ->
+                onAddReminder(reminder)
+                showAddReminderDialog = false
+            },
+            onDismiss = { showAddReminderDialog = false }
+        )
+    }
+
+    if (editingReminder != null) {
+        ReminderEditDialog(
+            existingReminder = editingReminder,
+            setId = setWithItems.set.id,
+            onSave = { reminder ->
+                onUpdateReminder(reminder)
+                editingReminder = null
+            },
+            onDismiss = { editingReminder = null }
+        )
+    }
+}
+
+@Composable
+private fun ReminderRow(
+    reminder: MedicationSetReminder,
+    onToggle: (Boolean) -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 40.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Alarm,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = formatTime(reminder.hour, reminder.minute),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer
+            )
+            Text(
+                text = DaysOfWeek.toDisplayString(reminder.daysOfWeek),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+            )
+        }
+        Switch(
+            checked = reminder.enabled,
+            onCheckedChange = onToggle
+        )
+        IconButton(onClick = onEdit, modifier = Modifier.size(32.dp)) {
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = "Edit reminder",
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+            )
+        }
+        IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "Delete reminder",
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+            )
+        }
+    }
+}
+
+private fun formatTime(hour: Int, minute: Int): String {
+    val period = if (hour < 12) "AM" else "PM"
+    val displayHour = when {
+        hour == 0 -> 12
+        hour > 12 -> hour - 12
+        else -> hour
+    }
+    return "%d:%02d %s".format(displayHour, minute, period)
 }

--- a/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
@@ -6,6 +6,8 @@ import com.privatehealthjournal.data.dao.CholesterolDao
 import com.privatehealthjournal.data.dao.MealDao
 import com.privatehealthjournal.data.dao.MedicationDao
 import com.privatehealthjournal.data.dao.MedicationSetDao
+import com.privatehealthjournal.data.dao.MedicationSetLogDao
+import com.privatehealthjournal.data.dao.MedicationSetReminderDao
 import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.SpO2Dao
@@ -37,6 +39,8 @@ class LogRepositoryTest {
     private lateinit var spO2Dao: SpO2Dao
     private lateinit var bloodGlucoseDao: BloodGlucoseDao
     private lateinit var medicationSetDao: MedicationSetDao
+    private lateinit var medicationSetReminderDao: MedicationSetReminderDao
+    private lateinit var medicationSetLogDao: MedicationSetLogDao
     private lateinit var repository: LogRepository
 
     @Before
@@ -52,6 +56,8 @@ class LogRepositoryTest {
         spO2Dao = mockk(relaxed = true)
         bloodGlucoseDao = mockk(relaxed = true)
         medicationSetDao = mockk(relaxed = true)
+        medicationSetReminderDao = mockk(relaxed = true)
+        medicationSetLogDao = mockk(relaxed = true)
 
         every { mealDao.getAllMealsWithDetails() } returns flowOf(emptyList())
         every { mealDao.getAllTags() } returns flowOf(emptyList())
@@ -79,7 +85,9 @@ class LogRepositoryTest {
             weightDao,
             spO2Dao,
             bloodGlucoseDao,
-            medicationSetDao
+            medicationSetDao,
+            medicationSetReminderDao,
+            medicationSetLogDao
         )
     }
 


### PR DESCRIPTION
Allow users to set multiple daily reminders on each medication set with day-of-week selection. Reminders use exact alarms and check whether the set has already been logged today before posting a notification.