### PR TITLE
feat: add meal point budget system

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
     implementation("androidx.room:room-ktx:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")
 
+    // DataStore
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
     // Charting - Vico
     implementation("com.patrykandpatrick.vico:compose-m3:1.15.0")
 

--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -35,6 +35,7 @@ import com.privatehealthjournal.ui.screens.BiometricsChartScreen
 import com.privatehealthjournal.ui.screens.CalendarScreen
 import com.privatehealthjournal.ui.screens.HistoryScreen
 import com.privatehealthjournal.ui.screens.HomeScreen
+import com.privatehealthjournal.ui.screens.MealBudgetScreen
 import com.privatehealthjournal.ui.screens.MedicationSetsScreen
 import com.privatehealthjournal.ui.screens.SettingsScreen
 import com.privatehealthjournal.notification.ReminderBroadcastReceiver
@@ -104,7 +105,8 @@ class MainActivity : ComponentActivity() {
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
                                 onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onViewMedicationSets = { navController.navigate("medication_sets") }
+                                onViewMedicationSets = { navController.navigate("medication_sets") },
+                                onViewMealBudget = { navController.navigate("meal_budget") }
                             )
                         }
                         composable(
@@ -201,6 +203,13 @@ class MainActivity : ComponentActivity() {
                             SettingsScreen(
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() }
+                            )
+                        }
+                        composable("meal_budget") {
+                            MealBudgetScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                onNavigateToSettings = { navController.navigate("settings") }
                             )
                         }
                         composable("biometrics_chart") {

--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.BloodPressureDao
 import com.privatehealthjournal.data.dao.BowelMovementDao
@@ -55,7 +57,7 @@ import com.privatehealthjournal.data.entity.WeightEntry
         MedicationSetReminder::class,
         MedicationSetLog::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -77,6 +79,13 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        private val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE meal_entries ADD COLUMN pointCost INTEGER")
+                database.execSQL("ALTER TABLE other_entries ADD COLUMN pointCredit INTEGER")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -84,7 +93,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "food_symptom_log_database"
                 )
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(MIGRATION_11_12)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MealEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MealEntry.kt
@@ -16,5 +16,6 @@ data class MealEntry(
     val id: Long = 0,
     val mealType: MealType,
     val notes: String = "",
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val pointCost: Int? = null
 )

--- a/app/src/main/java/com/privatehealthjournal/data/entity/OtherEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/OtherEntry.kt
@@ -21,5 +21,6 @@ data class OtherEntry(
     val subType: String = "",
     val value: String = "",
     val notes: String = "",
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val pointCredit: Int? = null
 )

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
@@ -35,7 +35,8 @@ object DataExporter {
                     notes = meal.meal.notes,
                     timestamp = meal.meal.timestamp,
                     foods = meal.foods.map { it.name },
-                    tags = meal.tags.map { it.name }
+                    tags = meal.tags.map { it.name },
+                    pointCost = meal.meal.pointCost
                 )
             },
             symptoms = symptoms.map { symptom ->
@@ -61,7 +62,8 @@ object DataExporter {
                     subType = other.subType,
                     value = other.value,
                     notes = other.notes,
-                    timestamp = other.timestamp
+                    timestamp = other.timestamp,
+                    pointCredit = other.pointCredit
                 )
             },
             bloodPressureEntries = bloodPressureEntries.map { bp ->

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
@@ -48,7 +48,8 @@ object DataImporter {
                     foods = meal.foods,
                     tags = meal.tags,
                     notes = meal.notes,
-                    timestamp = meal.timestamp
+                    timestamp = meal.timestamp,
+                    pointCost = meal.pointCost
                 )
                 mealsImported++
             }
@@ -93,7 +94,8 @@ object DataImporter {
                         subType = other.subType,
                         value = other.value,
                         notes = other.notes,
-                        timestamp = other.timestamp
+                        timestamp = other.timestamp,
+                        pointCredit = other.pointCredit
                     )
                 )
                 otherEntriesImported++

--- a/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
@@ -20,7 +20,8 @@ data class ExportedMeal(
     val notes: String,
     val timestamp: Long,
     val foods: List<String>,
-    val tags: List<String>
+    val tags: List<String>,
+    val pointCost: Int? = null
 )
 
 data class ExportedSymptom(
@@ -43,7 +44,8 @@ data class ExportedOtherEntry(
     val subType: String,
     val value: String,
     val notes: String,
-    val timestamp: Long
+    val timestamp: Long,
+    val pointCredit: Int? = null
 )
 
 data class ExportedBloodPressure(

--- a/app/src/main/java/com/privatehealthjournal/data/preferences/BudgetPreferences.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/preferences/BudgetPreferences.kt
@@ -1,0 +1,27 @@
+package com.privatehealthjournal.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.budgetDataStore: DataStore<Preferences> by preferencesDataStore(name = "budget")
+
+object BudgetPreferences {
+    val DAILY_BUDGET = intPreferencesKey("daily_budget")
+
+    fun getDailyBudget(context: Context): Flow<Int?> =
+        context.budgetDataStore.data.map { prefs -> prefs[DAILY_BUDGET] }
+
+    suspend fun setDailyBudget(context: Context, budget: Int) {
+        context.budgetDataStore.edit { prefs -> prefs[DAILY_BUDGET] = budget }
+    }
+
+    suspend fun clearDailyBudget(context: Context) {
+        context.budgetDataStore.edit { prefs -> prefs.remove(DAILY_BUDGET) }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
@@ -112,9 +112,10 @@ class LogRepository(
         foods: List<String>,
         tags: List<String>,
         notes: String = "",
-        timestamp: Long = System.currentTimeMillis()
+        timestamp: Long = System.currentTimeMillis(),
+        pointCost: Int? = null
     ): Long {
-        val meal = MealEntry(mealType = mealType, notes = notes, timestamp = timestamp)
+        val meal = MealEntry(mealType = mealType, notes = notes, timestamp = timestamp, pointCost = pointCost)
         return mealDao.insertMealWithDetails(meal, foods, tags)
     }
 

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
@@ -49,6 +49,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.MealEntry
 import com.privatehealthjournal.data.entity.MealType
@@ -76,6 +78,7 @@ fun AddMealScreen(
     val tags = remember { mutableStateListOf<String>() }
     var currentTag by remember { mutableStateOf("") }
     var notes by remember { mutableStateOf("") }
+    var pointCostText by remember { mutableStateOf("") }
     var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by remember { mutableStateOf<Long?>(null) }
 
@@ -98,6 +101,7 @@ fun AddMealScreen(
             tags.clear()
             tags.addAll(mealWithDetails.tags.map { it.name })
             notes = mealWithDetails.meal.notes
+            pointCostText = mealWithDetails.meal.pointCost?.toString() ?: ""
             timestamp = mealWithDetails.meal.timestamp
             existingId = mealWithDetails.meal.id
         }
@@ -415,18 +419,36 @@ fun AddMealScreen(
                 maxLines = 3
             )
 
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = pointCostText,
+                onValueChange = { newVal ->
+                    if (newVal.isEmpty() || newVal.all { it.isDigit() }) {
+                        pointCostText = newVal
+                    }
+                },
+                label = { Text("Point Cost (optional)") },
+                placeholder = { Text("e.g., 8") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+
             Spacer(modifier = Modifier.height(24.dp))
 
             Button(
                 onClick = {
                     if (foods.isNotEmpty()) {
+                        val pointCost = pointCostText.toIntOrNull()
                         if (isEditMode && existingId != null) {
                             viewModel.updateMeal(
                                 meal = MealEntry(
                                     id = existingId!!,
                                     mealType = selectedMealType,
                                     notes = notes.trim(),
-                                    timestamp = timestamp
+                                    timestamp = timestamp,
+                                    pointCost = pointCost
                                 ),
                                 foods = foods.toList(),
                                 tags = tags.toList()
@@ -437,7 +459,8 @@ fun AddMealScreen(
                                 foods = foods.toList(),
                                 tags = tags.toList(),
                                 notes = notes.trim(),
-                                timestamp = timestamp
+                                timestamp = timestamp,
+                                pointCost = pointCost
                             )
                         }
                         viewModel.clearEditingState()

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
@@ -79,6 +79,7 @@ fun AddOtherEntryScreen(
     var subType by remember { mutableStateOf("") }
     var value by remember { mutableStateOf("") }
     var notes by remember { mutableStateOf("") }
+    var pointCreditText by remember { mutableStateOf("") }
     var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by remember { mutableStateOf<Long?>(null) }
 
@@ -99,6 +100,7 @@ fun AddOtherEntryScreen(
             subType = entry.subType
             value = entry.value
             notes = entry.notes
+            pointCreditText = entry.pointCredit?.toString() ?: ""
             timestamp = entry.timestamp
             existingId = entry.id
             if (entry.entryType == OtherEntryType.BOWEL_MOVEMENT) {
@@ -200,6 +202,20 @@ fun AddOtherEntryScreen(
                         placeholder = { Text("e.g., 30 minutes") },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = pointCreditText,
+                        onValueChange = { newVal ->
+                            if (newVal.isEmpty() || newVal.all { it.isDigit() }) {
+                                pointCreditText = newVal
+                            }
+                        },
+                        label = { Text("Point Credit (optional)") },
+                        placeholder = { Text("Points earned back") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
                     )
                 }
                 OtherEntryType.STRESS -> {
@@ -322,6 +338,9 @@ fun AddOtherEntryScreen(
                     } else {
                         value.trim()
                     }
+                    val pointCredit = if (selectedType == OtherEntryType.EXERCISE) {
+                        pointCreditText.toIntOrNull()
+                    } else null
 
                     val entry = OtherEntry(
                         id = if (isEditMode) existingId ?: 0 else 0,
@@ -329,7 +348,8 @@ fun AddOtherEntryScreen(
                         subType = subType.trim(),
                         value = finalValue,
                         notes = notes.trim(),
-                        timestamp = timestamp
+                        timestamp = timestamp,
+                        pointCredit = pointCredit
                     )
 
                     if (isEditMode && existingId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Savings
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Warning
@@ -100,7 +101,8 @@ fun HomeScreen(
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
     onEditBloodGlucose: (Long) -> Unit = {},
-    onViewMedicationSets: () -> Unit = {}
+    onViewMedicationSets: () -> Unit = {},
+    onViewMealBudget: () -> Unit = {}
 ) {
     val recentMeals by viewModel.recentMeals.collectAsState()
     val recentSymptoms by viewModel.recentSymptomEntries.collectAsState()
@@ -126,6 +128,12 @@ fun HomeScreen(
                     )
                 },
                 actions = {
+                    IconButton(onClick = onViewMealBudget) {
+                        Icon(
+                            imageVector = Icons.Default.Savings,
+                            contentDescription = "Meal Budget"
+                        )
+                    }
                     IconButton(onClick = onViewCalendar) {
                         Icon(
                             imageVector = Icons.Default.CalendarMonth,

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
@@ -1,0 +1,565 @@
+package com.privatehealthjournal.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.MealType
+import com.privatehealthjournal.data.entity.MealWithDetails
+import com.privatehealthjournal.data.entity.OtherEntry
+import com.privatehealthjournal.data.entity.OtherEntryType
+import com.privatehealthjournal.viewmodel.LogViewModel
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MealBudgetScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    onNavigateToSettings: () -> Unit
+) {
+    val allMeals by viewModel.allMeals.collectAsState()
+    val allOtherEntries by viewModel.allOtherEntries.collectAsState()
+    val dailyBudgetState by viewModel.dailyBudget.collectAsState()
+    val dailyBudget = dailyBudgetState
+
+    var weekOffset by remember { mutableIntStateOf(0) }
+    var selectedDay by remember { mutableStateOf<LocalDate?>(null) }
+
+    val today = LocalDate.now()
+    val weekStart = today.plusWeeks(weekOffset.toLong())
+        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    val weekEnd = weekStart.plusDays(6)
+
+    val weekStartMs = weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    val weekEndMs = weekEnd.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+    val zone = ZoneId.systemDefault()
+
+    val weekMeals = allMeals.filter { it.meal.timestamp in weekStartMs until weekEndMs }
+    val weekExercise = allOtherEntries.filter {
+        it.entryType == OtherEntryType.EXERCISE && it.timestamp in weekStartMs until weekEndMs
+    }
+
+    val weeklyMealPoints = weekMeals.sumOf { it.meal.pointCost ?: 0 }
+    val weeklyExerciseCredits = weekExercise.sumOf { it.pointCredit ?: 0 }
+    val netWeeklyPoints = weeklyMealPoints - weeklyExerciseCredits
+
+    val weeklyBudget = (dailyBudget ?: 0) * 8
+    val weeklyRemaining = weeklyBudget - netWeeklyPoints
+
+    // Sum of each day's overage (how much was drawn from the overage pool)
+    val overageUsed = (0..6).sumOf { dayOffset ->
+        val day = weekStart.plusDays(dayOffset.toLong())
+        if (day.isAfter(today)) return@sumOf 0
+        val dayStartMs = day.atStartOfDay(zone).toInstant().toEpochMilli()
+        val dayEndMs = day.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        val dayMealPts = allMeals
+            .filter { it.meal.timestamp in dayStartMs until dayEndMs }
+            .sumOf { it.meal.pointCost ?: 0 }
+        val dayExercisePts = allOtherEntries
+            .filter { it.entryType == OtherEntryType.EXERCISE && it.timestamp in dayStartMs until dayEndMs }
+            .sumOf { it.pointCredit ?: 0 }
+        maxOf(0, dayMealPts - dayExercisePts - (dailyBudget ?: 0))
+    }
+
+    val headerFormatter = DateTimeFormatter.ofPattern("MMM d")
+    val dayFormatter = DateTimeFormatter.ofPattern("EEE\nMMM d")
+    val isCurrentWeek = weekOffset == 0
+
+    // Reset selected day when week changes
+    val weekKey = weekOffset
+    remember(weekKey) { selectedDay = null }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Meal Budget", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            if (dailyBudget == null) {
+                NoBudgetCard(onNavigateToSettings)
+            } else {
+
+            // Week navigation
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                IconButton(onClick = {
+                    weekOffset--
+                    selectedDay = null
+                }) {
+                    Icon(Icons.Default.ChevronLeft, contentDescription = "Previous week")
+                }
+                Text(
+                    text = "${weekStart.format(headerFormatter)} – ${weekEnd.format(headerFormatter)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                IconButton(
+                    onClick = {
+                        weekOffset++
+                        selectedDay = null
+                    },
+                    enabled = !isCurrentWeek
+                ) {
+                    Icon(
+                        Icons.Default.ChevronRight,
+                        contentDescription = "Next week",
+                        tint = if (!isCurrentWeek) MaterialTheme.colorScheme.onSurface
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Weekly summary card
+            WeeklySummaryCard(
+                dailyBudget = dailyBudget,
+                weeklyBudget = weeklyBudget,
+                netWeeklyPoints = netWeeklyPoints,
+                weeklyMealPoints = weeklyMealPoints,
+                weeklyExerciseCredits = weeklyExerciseCredits,
+                weeklyRemaining = weeklyRemaining,
+                overageUsed = overageUsed
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Daily breakdown
+            Text(
+                text = "Daily Breakdown",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            (0..6).forEach { dayOffset ->
+                val day = weekStart.plusDays(dayOffset.toLong())
+                val dayStartMs = day.atStartOfDay(zone).toInstant().toEpochMilli()
+                val dayEndMs = day.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+                val isFuture = day.isAfter(today)
+
+                val dayMeals = allMeals.filter { it.meal.timestamp in dayStartMs until dayEndMs }
+                val dayExercise = allOtherEntries.filter {
+                    it.entryType == OtherEntryType.EXERCISE && it.timestamp in dayStartMs until dayEndMs
+                }
+                val dayMealPoints = dayMeals.sumOf { it.meal.pointCost ?: 0 }
+                val dayExerciseCredits = dayExercise.sumOf { it.pointCredit ?: 0 }
+                val dayNet = dayMealPoints - dayExerciseCredits
+                val isExpanded = selectedDay == day
+
+                DayRow(
+                    day = day,
+                    dayNet = dayNet,
+                    dailyBudget = dailyBudget,
+                    isFuture = isFuture,
+                    isToday = day == today,
+                    isExpanded = isExpanded,
+                    dayMeals = dayMeals,
+                    dayExercise = dayExercise,
+                    dayFormatter = dayFormatter,
+                    onClick = {
+                        selectedDay = if (isExpanded) null else day
+                    }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            } // end else (budget set)
+        }
+    }
+}
+
+@Composable
+private fun NoBudgetCard(onNavigateToSettings: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "No budget set",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Set your daily point budget in Settings to start tracking.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            androidx.compose.material3.Button(onClick = onNavigateToSettings) {
+                Icon(Icons.Default.Settings, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Open Settings")
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeeklySummaryCard(
+    dailyBudget: Int,
+    weeklyBudget: Int,
+    netWeeklyPoints: Int,
+    weeklyMealPoints: Int,
+    weeklyExerciseCredits: Int,
+    weeklyRemaining: Int,
+    overageUsed: Int
+) {
+    val overageBudget = dailyBudget
+    val progress = if (weeklyBudget > 0) (netWeeklyPoints.toFloat() / weeklyBudget).coerceIn(0f, 1f) else 0f
+    val isOver = netWeeklyPoints > weeklyBudget
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = when {
+                isOver -> MaterialTheme.colorScheme.errorContainer
+                netWeeklyPoints > dailyBudget * 7 -> MaterialTheme.colorScheme.tertiaryContainer
+                else -> MaterialTheme.colorScheme.primaryContainer
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "This Week",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Bottom
+            ) {
+                Text(
+                    text = "$netWeeklyPoints pts",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "/ $weeklyBudget pts",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.fillMaxWidth(),
+                color = if (isOver) MaterialTheme.colorScheme.error
+                else if (netWeeklyPoints > dailyBudget * 7) MaterialTheme.colorScheme.tertiary
+                else MaterialTheme.colorScheme.primary,
+                trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "$dailyBudget pts/day × 7 days + $dailyBudget overage = $weeklyBudget total",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+            if (weeklyExerciseCredits > 0) {
+                Text(
+                    text = "Meal pts: $weeklyMealPoints  |  Exercise credits: −$weeklyExerciseCredits",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = when {
+                    isOver -> "${-weeklyRemaining} pts over weekly budget"
+                    overageUsed > 0 -> "$overageUsed / $overageBudget overage pts used  •  $weeklyRemaining pts remaining"
+                    else -> "$weeklyRemaining pts remaining  •  $overageBudget overage pts available"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = if (isOver) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun DayRow(
+    day: LocalDate,
+    dayNet: Int,
+    dailyBudget: Int,
+    isFuture: Boolean,
+    isToday: Boolean,
+    isExpanded: Boolean,
+    dayMeals: List<MealWithDetails>,
+    dayExercise: List<OtherEntry>,
+    dayFormatter: DateTimeFormatter,
+    onClick: () -> Unit
+) {
+    val progress = if (dailyBudget > 0) (dayNet.toFloat() / dailyBudget).coerceIn(0f, 1f) else 0f
+    val isOver = dayNet > dailyBudget
+    val hasItems = dayMeals.isNotEmpty() || dayExercise.isNotEmpty()
+    val barColor = when {
+        isFuture -> Color.Transparent
+        isOver -> MaterialTheme.colorScheme.error
+        dayNet > dailyBudget * 0.8f -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isFuture && hasItems, onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = when {
+                isToday -> MaterialTheme.colorScheme.secondaryContainer
+                isFuture -> MaterialTheme.colorScheme.surface
+                else -> MaterialTheme.colorScheme.surfaceVariant
+            }
+        )
+    ) {
+        Column {
+            // Summary row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.width(48.dp)
+                ) {
+                    Text(
+                        text = day.format(dayFormatter),
+                        style = MaterialTheme.typography.labelSmall,
+                        textAlign = TextAlign.Center,
+                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                        color = if (isToday) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    if (!isFuture) {
+                        LinearProgressIndicator(
+                            progress = { progress },
+                            modifier = Modifier.fillMaxWidth(),
+                            color = barColor,
+                            trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
+                        )
+                    }
+                }
+                Text(
+                    text = if (isFuture) "—" else "$dayNet pts",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = when {
+                        isFuture -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                        isOver -> MaterialTheme.colorScheme.error
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier.width(56.dp),
+                    textAlign = TextAlign.End
+                )
+                if (!isFuture && hasItems) {
+                    Icon(
+                        imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+            }
+
+            // Expanded items
+            if (isExpanded) {
+                Divider(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                )
+                Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    dayMeals.forEach { mealWithDetails ->
+                        val meal = mealWithDetails.meal
+                        val foods = mealWithDetails.foods.joinToString(", ") { it.name }
+                        val mealTime = Instant.ofEpochMilli(meal.timestamp)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalTime()
+                            .format(timeFormatter)
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Restaurant,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "${mealTypeName(meal.mealType)}  ·  $mealTime",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                if (foods.isNotEmpty()) {
+                                    Text(
+                                        text = foods,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                    )
+                                }
+                            }
+                            Text(
+                                text = if (meal.pointCost != null) "${meal.pointCost} pts" else "—",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Medium,
+                                color = if (meal.pointCost != null) MaterialTheme.colorScheme.onSurface
+                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+
+                    dayExercise.forEach { exercise ->
+                        val exerciseTime = Instant.ofEpochMilli(exercise.timestamp)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalTime()
+                            .format(timeFormatter)
+                        val label = buildString {
+                            if (exercise.subType.isNotBlank()) append(exercise.subType)
+                            if (exercise.value.isNotBlank()) {
+                                if (isNotEmpty()) append("  ·  ")
+                                append(exercise.value)
+                            }
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.DirectionsRun,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.tertiary
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Exercise  ·  $exerciseTime",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                if (label.isNotEmpty()) {
+                                    Text(
+                                        text = label,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                    )
+                                }
+                            }
+                            Text(
+                                text = if (exercise.pointCredit != null) "−${exercise.pointCredit} pts" else "—",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Medium,
+                                color = if (exercise.pointCredit != null) Color(0xFF4CAF50)
+                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun mealTypeName(type: MealType) = when (type) {
+    MealType.BREAKFAST -> "Breakfast"
+    MealType.LUNCH -> "Lunch"
+    MealType.DINNER -> "Dinner"
+    MealType.SNACK -> "Snack"
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
@@ -9,6 +9,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.FileDownload
@@ -23,15 +27,22 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.text.SimpleDateFormat
@@ -49,6 +60,13 @@ fun SettingsScreen(
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
     val allMedications by viewModel.allMedications.collectAsState()
     val allOtherEntries by viewModel.allOtherEntries.collectAsState()
+    val dailyBudget by viewModel.dailyBudget.collectAsState()
+
+    var budgetText by remember { mutableStateOf("") }
+
+    LaunchedEffect(dailyBudget) {
+        budgetText = dailyBudget?.toString() ?: ""
+    }
 
     val totalEntries = allMeals.size + allSymptoms.size + allMedications.size + allOtherEntries.size
 
@@ -100,6 +118,7 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .padding(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             // Data summary
             Card(
@@ -125,6 +144,61 @@ fun SettingsScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Meal Budget settings
+            Text(
+                text = "Meal Budget",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Set your daily point budget. A weekly overage of one extra day's budget is included for flexibility.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = budgetText,
+                onValueChange = { newVal ->
+                    if (newVal.isEmpty() || newVal.all { it.isDigit() }) {
+                        budgetText = newVal
+                    }
+                },
+                label = { Text("Daily Point Budget") },
+                placeholder = { Text("e.g., 30") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = { viewModel.saveDailyBudget(budgetText.toIntOrNull()) }
+                ),
+                supportingText = if (budgetText.isNotBlank()) {
+                    val daily = budgetText.toIntOrNull()
+                    if (daily != null) {
+                        { Text("Weekly total: ${daily * 8} pts (${daily * 7} + ${daily} overage)") }
+                    } else null
+                } else null
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = { viewModel.saveDailyBudget(budgetText.toIntOrNull()) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = budgetText.toIntOrNull() != null || (budgetText.isEmpty() && dailyBudget != null)
+            ) {
+                Text(if (budgetText.isEmpty() && dailyBudget != null) "Clear Budget" else "Save Budget")
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
@@ -29,6 +29,7 @@ import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.Tag
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.data.entity.WeightUnit
+import com.privatehealthjournal.data.preferences.BudgetPreferences
 import com.privatehealthjournal.data.repository.LogRepository
 import com.privatehealthjournal.notification.ReminderScheduler
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -74,6 +75,7 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     val stressSources: StateFlow<List<String>>
     val moodDescriptions: StateFlow<List<String>>
     val otherCategories: StateFlow<List<String>>
+    val dailyBudget: StateFlow<Int?>
 
     init {
         val database = AppDatabase.getDatabase(application)
@@ -189,6 +191,9 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
 
         otherCategories = repository.getDistinctOtherSubTypes(OtherEntryType.OTHER)
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        dailyBudget = BudgetPreferences.getDailyBudget(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, null)
     }
 
     fun addMeal(
@@ -196,10 +201,21 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         foods: List<String>,
         tags: List<String>,
         notes: String = "",
-        timestamp: Long = System.currentTimeMillis()
+        timestamp: Long = System.currentTimeMillis(),
+        pointCost: Int? = null
     ) {
         viewModelScope.launch {
-            repository.insertMeal(mealType, foods, tags, notes, timestamp)
+            repository.insertMeal(mealType, foods, tags, notes, timestamp, pointCost)
+        }
+    }
+
+    fun saveDailyBudget(budget: Int?) {
+        viewModelScope.launch {
+            if (budget == null) {
+                BudgetPreferences.clearDailyBudget(getApplication())
+            } else {
+                BudgetPreferences.setDailyBudget(getApplication(), budget)
+            }
         }
     }
 


### PR DESCRIPTION
- pointCost on MealEntry, pointCredit on OtherEntry (EXERCISE only)
- DB migration 11→12 preserves existing data
- DataStore-backed daily budget setting (BudgetPreferences)
- MealBudgetScreen: weekly summary + daily breakdown with per-day expand to show meals and exercise entries
- Overage pool (1 day's budget) drains by individual daily overages, not weekly total
- Budget accessible via Savings icon in HomeScreen top bar
- Export/import includes new point fields