### PR TITLE
fix(db): add migrations 8-11 to prevent crash on upgrade

### DIFF
--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -79,6 +79,68 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `blood_glucose_entries` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `glucoseLevel` REAL NOT NULL,
+                        `unit` TEXT NOT NULL,
+                        `mealContext` TEXT,
+                        `notes` TEXT NOT NULL,
+                        `timestamp` INTEGER NOT NULL
+                    )
+                """.trimIndent())
+            }
+        }
+
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `medication_sets` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `name` TEXT NOT NULL
+                    )
+                """.trimIndent())
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `medication_set_items` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `setId` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `dosage` TEXT NOT NULL,
+                        FOREIGN KEY(`setId`) REFERENCES `medication_sets`(`id`) ON DELETE CASCADE
+                    )
+                """.trimIndent())
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_set_items_setId` ON `medication_set_items` (`setId`)")
+            }
+        }
+
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `medication_set_reminders` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `setId` INTEGER NOT NULL,
+                        `hour` INTEGER NOT NULL,
+                        `minute` INTEGER NOT NULL,
+                        `daysOfWeek` INTEGER NOT NULL,
+                        `enabled` INTEGER NOT NULL,
+                        FOREIGN KEY(`setId`) REFERENCES `medication_sets`(`id`) ON DELETE CASCADE
+                    )
+                """.trimIndent())
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_set_reminders_setId` ON `medication_set_reminders` (`setId`)")
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `medication_set_logs` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `setId` INTEGER NOT NULL,
+                        `timestamp` INTEGER NOT NULL,
+                        FOREIGN KEY(`setId`) REFERENCES `medication_sets`(`id`) ON DELETE CASCADE
+                    )
+                """.trimIndent())
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_set_logs_setId` ON `medication_set_logs` (`setId`)")
+            }
+        }
+
         private val MIGRATION_11_12 = object : Migration(11, 12) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE meal_entries ADD COLUMN pointCost INTEGER")
@@ -93,7 +155,8 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "food_symptom_log_database"
                 )
-                    .addMigrations(MIGRATION_11_12)
+                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
+                    .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance
                 instance


### PR DESCRIPTION
Users upgrading from v0.3.0 (DB v8) crashed because only MIGRATION_11_12 existed. App threw IllegalStateException: migration from 8 to 12 required.

- 8→9: create blood_glucose_entries
- 9→10: create medication_sets + medication_set_items
- 10→11: create medication_set_reminders + medication_set_logs
- add fallbackToDestructiveMigration() for anything older than v8