### PR TITLE
feat: add menstrual cycle tracking

### DIFF
--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.navigation.navArgument
 import com.privatehealthjournal.ui.screens.AddBloodGlucoseScreen
 import com.privatehealthjournal.ui.screens.AddBloodPressureScreen
 import com.privatehealthjournal.ui.screens.AddCholesterolScreen
+import com.privatehealthjournal.ui.screens.AddCycleEntryScreen
 import com.privatehealthjournal.ui.screens.AddMealScreen
 import com.privatehealthjournal.ui.screens.AddMedicationScreen
 import com.privatehealthjournal.ui.screens.AddMedicationSetScreen
@@ -33,6 +34,7 @@ import com.privatehealthjournal.ui.screens.AddSymptomScreen
 import com.privatehealthjournal.ui.screens.AddWeightScreen
 import com.privatehealthjournal.ui.screens.BiometricsChartScreen
 import com.privatehealthjournal.ui.screens.CalendarScreen
+import com.privatehealthjournal.ui.screens.CycleTrackingScreen
 import com.privatehealthjournal.ui.screens.HistoryScreen
 import com.privatehealthjournal.ui.screens.HomeScreen
 import com.privatehealthjournal.ui.screens.MealBudgetScreen
@@ -106,7 +108,9 @@ class MainActivity : ComponentActivity() {
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
                                 onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
                                 onViewMedicationSets = { navController.navigate("medication_sets") },
-                                onViewMealBudget = { navController.navigate("meal_budget") }
+                                onViewMealBudget = { navController.navigate("meal_budget") },
+                                onViewCycleTracking = { navController.navigate("cycle_tracking") },
+                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
                             )
                         }
                         composable(
@@ -230,7 +234,8 @@ class MainActivity : ComponentActivity() {
                                 onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
-                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") }
+                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
+                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
                             )
                         }
                         composable("history") {
@@ -245,7 +250,33 @@ class MainActivity : ComponentActivity() {
                                 onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
-                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") }
+                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
+                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
+                            )
+                        }
+                        composable("cycle_tracking") {
+                            CycleTrackingScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                onAddEntry = { navController.navigate("add_cycle_entry") },
+                                onEditEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
+                            )
+                        }
+                        composable("add_cycle_entry") {
+                            AddCycleEntryScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() }
+                            )
+                        }
+                        composable(
+                            route = "edit_cycle_entry/{cycleEntryId}",
+                            arguments = listOf(navArgument("cycleEntryId") { type = NavType.LongType })
+                        ) { backStackEntry ->
+                            val cycleEntryId = backStackEntry.arguments?.getLong("cycleEntryId")
+                            AddCycleEntryScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                editId = cycleEntryId
                             )
                         }
                         composable("medication_sets") {

--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -10,6 +10,7 @@ import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.BloodPressureDao
 import com.privatehealthjournal.data.dao.BowelMovementDao
 import com.privatehealthjournal.data.dao.CholesterolDao
+import com.privatehealthjournal.data.dao.CycleEntryDao
 import com.privatehealthjournal.data.dao.MealDao
 import com.privatehealthjournal.data.dao.MedicationDao
 import com.privatehealthjournal.data.dao.MedicationSetDao
@@ -23,6 +24,7 @@ import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.BowelMovementEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.FoodItem
 import com.privatehealthjournal.data.entity.MealEntry
 import com.privatehealthjournal.data.entity.MealTagCrossRef
@@ -55,9 +57,10 @@ import com.privatehealthjournal.data.entity.WeightEntry
         MedicationSet::class,
         MedicationSetItem::class,
         MedicationSetReminder::class,
-        MedicationSetLog::class
+        MedicationSetLog::class,
+        CycleEntry::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -74,6 +77,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun medicationSetDao(): MedicationSetDao
     abstract fun medicationSetReminderDao(): MedicationSetReminderDao
     abstract fun medicationSetLogDao(): MedicationSetLogDao
+    abstract fun cycleEntryDao(): CycleEntryDao
 
     companion object {
         @Volatile
@@ -148,6 +152,20 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `cycle_entries` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `flow` TEXT NOT NULL,
+                        `symptoms` TEXT NOT NULL,
+                        `notes` TEXT NOT NULL,
+                        `timestamp` INTEGER NOT NULL
+                    )
+                """.trimIndent())
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -155,7 +173,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "food_symptom_log_database"
                 )
-                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
+                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
                     .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/privatehealthjournal/data/dao/CycleEntryDao.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/dao/CycleEntryDao.kt
@@ -1,0 +1,33 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.privatehealthjournal.data.entity.CycleEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CycleEntryDao {
+    @Query("SELECT * FROM cycle_entries ORDER BY timestamp DESC")
+    fun getAllCycleEntries(): Flow<List<CycleEntry>>
+
+    @Query("SELECT * FROM cycle_entries ORDER BY timestamp DESC LIMIT :limit")
+    fun getRecentCycleEntries(limit: Int): Flow<List<CycleEntry>>
+
+    @Query("SELECT * FROM cycle_entries WHERE id = :id")
+    suspend fun getById(id: Long): CycleEntry?
+
+    @Insert
+    suspend fun insert(entry: CycleEntry): Long
+
+    @Update
+    suspend fun update(entry: CycleEntry)
+
+    @Delete
+    suspend fun delete(entry: CycleEntry)
+
+    @Query("DELETE FROM cycle_entries WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/privatehealthjournal/data/entity/CycleEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/CycleEntry.kt
@@ -1,0 +1,39 @@
+package com.privatehealthjournal.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+enum class FlowIntensity(val displayLabel: String) {
+    SPOTTING("Spotting"),
+    LIGHT("Light"),
+    MEDIUM("Medium"),
+    HEAVY("Heavy")
+}
+
+enum class CycleSymptom(val displayLabel: String) {
+    CRAMPS("Cramps"),
+    BLOATING("Bloating"),
+    HEADACHE("Headache"),
+    FATIGUE("Fatigue"),
+    MOOD_SWINGS("Mood Swings"),
+    TENDER_BREASTS("Tender Breasts"),
+    ACNE("Acne"),
+    BACK_PAIN("Back Pain");
+
+    companion object {
+        fun encode(symptoms: Set<CycleSymptom>): String = symptoms.joinToString(",") { it.name }
+        fun decode(raw: String): Set<CycleSymptom> =
+            if (raw.isBlank()) emptySet()
+            else raw.split(",").mapNotNull { runCatching { valueOf(it.trim()) }.getOrNull() }.toSet()
+    }
+}
+
+@Entity(tableName = "cycle_entries")
+data class CycleEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val flow: FlowIntensity = FlowIntensity.MEDIUM,
+    val symptoms: String = "",
+    val notes: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
@@ -3,6 +3,7 @@ package com.privatehealthjournal.data.export
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.MealWithDetails
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.MedicationSetWithItems
@@ -26,7 +27,8 @@ object DataExporter {
         weightEntries: List<WeightEntry> = emptyList(),
         spO2Entries: List<SpO2Entry> = emptyList(),
         bloodGlucoseEntries: List<BloodGlucoseEntry> = emptyList(),
-        medicationSets: List<MedicationSetWithItems> = emptyList()
+        medicationSets: List<MedicationSetWithItems> = emptyList(),
+        cycleEntries: List<CycleEntry> = emptyList()
     ): String {
         val exportData = ExportData(
             meals = meals.map { meal ->
@@ -119,6 +121,14 @@ object DataExporter {
                             dosage = item.dosage
                         )
                     }
+                )
+            },
+            cycleEntries = cycleEntries.map { entry ->
+                ExportedCycleEntry(
+                    flow = entry.flow.name,
+                    symptoms = entry.symptoms,
+                    notes = entry.notes,
+                    timestamp = entry.timestamp
                 )
             }
         )

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
@@ -3,6 +3,8 @@ package com.privatehealthjournal.data.export
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
+import com.privatehealthjournal.data.entity.FlowIntensity
 import com.privatehealthjournal.data.entity.MealType
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
@@ -35,6 +37,7 @@ object DataImporter {
             var spO2Imported = 0
             var bloodGlucoseImported = 0
             var medicationSetsImported = 0
+            var cycleEntriesImported = 0
 
             // Import meals
             exportData.meals.forEach { meal ->
@@ -194,6 +197,24 @@ object DataImporter {
                 medicationSetsImported++
             }
 
+            // Import cycle entries
+            exportData.cycleEntries.forEach { entry ->
+                val flow = try {
+                    FlowIntensity.valueOf(entry.flow)
+                } catch (e: IllegalArgumentException) {
+                    FlowIntensity.MEDIUM
+                }
+                repository.insertCycleEntry(
+                    CycleEntry(
+                        flow = flow,
+                        symptoms = entry.symptoms,
+                        notes = entry.notes,
+                        timestamp = entry.timestamp
+                    )
+                )
+                cycleEntriesImported++
+            }
+
             ImportResult.Success(
                 mealsImported = mealsImported,
                 symptomsImported = symptomsImported,
@@ -204,7 +225,8 @@ object DataImporter {
                 weightImported = weightImported,
                 spO2Imported = spO2Imported,
                 bloodGlucoseImported = bloodGlucoseImported,
-                medicationSetsImported = medicationSetsImported
+                medicationSetsImported = medicationSetsImported,
+                cycleEntriesImported = cycleEntriesImported
             )
         } catch (e: Exception) {
             ImportResult.Error("Failed to import: ${e.message}")
@@ -223,12 +245,13 @@ sealed class ImportResult {
         val weightImported: Int = 0,
         val spO2Imported: Int = 0,
         val bloodGlucoseImported: Int = 0,
-        val medicationSetsImported: Int = 0
+        val medicationSetsImported: Int = 0,
+        val cycleEntriesImported: Int = 0
     ) : ImportResult() {
         val totalImported: Int
             get() = mealsImported + symptomsImported + medicationsImported + otherEntriesImported +
                     bloodPressureImported + cholesterolImported + weightImported + spO2Imported +
-                    bloodGlucoseImported + medicationSetsImported
+                    bloodGlucoseImported + medicationSetsImported + cycleEntriesImported
     }
 
     data class Error(val message: String) : ImportResult()

--- a/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
@@ -1,7 +1,7 @@
 package com.privatehealthjournal.data.export
 
 data class ExportData(
-    val version: Int = 3,
+    val version: Int = 4,
     val exportedAt: Long = System.currentTimeMillis(),
     val meals: List<ExportedMeal> = emptyList(),
     val symptoms: List<ExportedSymptom> = emptyList(),
@@ -12,7 +12,8 @@ data class ExportData(
     val weightEntries: List<ExportedWeight> = emptyList(),
     val spO2Entries: List<ExportedSpO2> = emptyList(),
     val bloodGlucoseEntries: List<ExportedBloodGlucose> = emptyList(),
-    val medicationSets: List<ExportedMedicationSet> = emptyList()
+    val medicationSets: List<ExportedMedicationSet> = emptyList(),
+    val cycleEntries: List<ExportedCycleEntry> = emptyList()
 )
 
 data class ExportedMeal(
@@ -95,4 +96,11 @@ data class ExportedMedicationSet(
 data class ExportedMedicationSetItem(
     val name: String,
     val dosage: String
+)
+
+data class ExportedCycleEntry(
+    val flow: String,
+    val symptoms: String,
+    val notes: String,
+    val timestamp: Long
 )

--- a/app/src/main/java/com/privatehealthjournal/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/preferences/AppPreferences.kt
@@ -1,0 +1,23 @@
+package com.privatehealthjournal.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.appDataStore: DataStore<Preferences> by preferencesDataStore(name = "app_preferences")
+
+object AppPreferences {
+    val SHOW_CYCLE_TRACKING = booleanPreferencesKey("show_cycle_tracking")
+
+    fun getShowCycleTracking(context: Context): Flow<Boolean> =
+        context.appDataStore.data.map { prefs -> prefs[SHOW_CYCLE_TRACKING] ?: true }
+
+    suspend fun setShowCycleTracking(context: Context, show: Boolean) {
+        context.appDataStore.edit { prefs -> prefs[SHOW_CYCLE_TRACKING] = show }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
@@ -4,6 +4,7 @@ import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.BloodPressureDao
 import com.privatehealthjournal.data.dao.BowelMovementDao
 import com.privatehealthjournal.data.dao.CholesterolDao
+import com.privatehealthjournal.data.dao.CycleEntryDao
 import com.privatehealthjournal.data.dao.MealDao
 import com.privatehealthjournal.data.dao.MedicationDao
 import com.privatehealthjournal.data.dao.MedicationSetDao
@@ -17,6 +18,7 @@ import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.BowelMovementEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.MealEntry
 import com.privatehealthjournal.data.entity.MealType
 import com.privatehealthjournal.data.entity.MealWithDetails
@@ -46,7 +48,8 @@ class LogRepository(
     private val bloodGlucoseDao: BloodGlucoseDao,
     private val medicationSetDao: MedicationSetDao,
     private val medicationSetReminderDao: MedicationSetReminderDao,
-    private val medicationSetLogDao: MedicationSetLogDao
+    private val medicationSetLogDao: MedicationSetLogDao,
+    private val cycleEntryDao: CycleEntryDao
 ) {
     val allMeals: Flow<List<MealWithDetails>> = mealDao.getAllMealsWithDetails()
     val allSymptomEntries: Flow<List<SymptomEntry>> = symptomEntryDao.getAllSymptomEntries()
@@ -64,6 +67,7 @@ class LogRepository(
     val allMedicationSets: Flow<List<MedicationSetWithItems>> = medicationSetDao.getAllSetsWithItems()
     val allFoodNames: Flow<List<String>> = mealDao.getAllFoodNames()
     val allSymptomNames: Flow<List<String>> = symptomEntryDao.getAllSymptomNames()
+    val allCycleEntries: Flow<List<CycleEntry>> = cycleEntryDao.getAllCycleEntries()
     fun getDistinctOtherSubTypes(type: OtherEntryType): Flow<List<String>> =
         otherEntryDao.getDistinctSubTypes(type)
 
@@ -105,6 +109,10 @@ class LogRepository(
 
     fun getRecentBloodGlucoseEntries(limit: Int = 5): Flow<List<BloodGlucoseEntry>> {
         return bloodGlucoseDao.getRecentBloodGlucoseEntries(limit)
+    }
+
+    fun getRecentCycleEntries(limit: Int = 5): Flow<List<CycleEntry>> {
+        return cycleEntryDao.getRecentCycleEntries(limit)
     }
 
     suspend fun insertMeal(
@@ -349,6 +357,12 @@ class LogRepository(
     // Medication Set Log methods
     suspend fun insertMedicationSetLog(log: MedicationSetLog): Long =
         medicationSetLogDao.insert(log)
+
+    // Cycle Entry methods
+    suspend fun insertCycleEntry(entry: CycleEntry): Long = cycleEntryDao.insert(entry)
+    suspend fun updateCycleEntry(entry: CycleEntry) = cycleEntryDao.update(entry)
+    suspend fun deleteCycleEntry(entry: CycleEntry) = cycleEntryDao.delete(entry)
+    suspend fun getCycleEntryById(id: Long): CycleEntry? = cycleEntryDao.getById(id)
 
     suspend fun hasSetBeenLoggedToday(setId: Long): Boolean {
         val calendar = java.util.Calendar.getInstance()

--- a/app/src/main/java/com/privatehealthjournal/ui/components/CycleEntryCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/CycleEntryCard.kt
@@ -1,0 +1,146 @@
+package com.privatehealthjournal.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.CycleEntry
+import com.privatehealthjournal.data.entity.CycleSymptom
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private val CycleRose = Color(0xFFE91E63)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CycleEntryCard(
+    entry: CycleEntry,
+    onDelete: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirm) {
+        DeleteConfirmationDialog(
+            onConfirm = { onDelete(); showDeleteConfirm = false },
+            onDismiss = { showDeleteConfirm = false }
+        )
+    }
+
+    val symptoms = CycleSymptom.decode(entry.symptoms)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = "Cycle",
+                tint = CycleRose,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Period",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = entry.flow.displayLabel,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = CycleRose
+                )
+                if (symptoms.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    FlowRow(horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(4.dp)) {
+                        symptoms.forEach { symptom ->
+                            SuggestionChip(
+                                onClick = {},
+                                label = { Text(symptom.displayLabel, style = MaterialTheme.typography.labelSmall) },
+                                colors = SuggestionChipDefaults.suggestionChipColors(
+                                    containerColor = CycleRose.copy(alpha = 0.12f)
+                                )
+                            )
+                        }
+                    }
+                }
+                if (entry.notes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatCycleTimestamp(entry.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+            }
+            Column {
+                if (onEdit != null) {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+                IconButton(onClick = { showDeleteConfirm = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatCycleTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy 'at' h:mm a", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
@@ -1,0 +1,221 @@
+package com.privatehealthjournal.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.CycleEntry
+import com.privatehealthjournal.data.entity.CycleSymptom
+import com.privatehealthjournal.data.entity.FlowIntensity
+import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.viewmodel.LogViewModel
+
+private val CycleRose = Color(0xFFE91E63)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AddCycleEntryScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    editId: Long? = null
+) {
+    val editingEntry by viewModel.editingCycleEntry.collectAsState()
+    val isEditMode = editId != null
+
+    var selectedFlow by remember { mutableStateOf(FlowIntensity.MEDIUM) }
+    var selectedSymptoms by remember { mutableStateOf(emptySet<CycleSymptom>()) }
+    var notes by remember { mutableStateOf("") }
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(editId) {
+        if (editId != null) {
+            viewModel.loadCycleEntryForEditing(editId)
+        }
+    }
+
+    LaunchedEffect(editingEntry) {
+        editingEntry?.let { entry ->
+            selectedFlow = entry.flow
+            selectedSymptoms = CycleSymptom.decode(entry.symptoms)
+            notes = entry.notes
+            timestamp = entry.timestamp
+            existingId = entry.id
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        if (isEditMode) "Edit Period Entry" else "Log Period",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.clearEditingState()
+                        onNavigateBack()
+                    }) {
+                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = null,
+                tint = CycleRose,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Text(
+                text = "Flow Intensity",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FlowIntensity.entries.forEach { intensity ->
+                    FilterChip(
+                        selected = selectedFlow == intensity,
+                        onClick = { selectedFlow = intensity },
+                        label = { Text(intensity.displayLabel) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = CycleRose,
+                            selectedLabelColor = Color.White
+                        )
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "Symptoms",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                CycleSymptom.entries.forEach { symptom ->
+                    FilterChip(
+                        selected = symptom in selectedSymptoms,
+                        onClick = {
+                            selectedSymptoms = if (symptom in selectedSymptoms) {
+                                selectedSymptoms - symptom
+                            } else {
+                                selectedSymptoms + symptom
+                            }
+                        },
+                        label = { Text(symptom.displayLabel) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = CycleRose.copy(alpha = 0.2f),
+                            selectedLabelColor = CycleRose
+                        )
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DateTimePicker(
+                timestamp = timestamp,
+                onTimestampChange = { timestamp = it },
+                label = "Date & Time"
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes (optional)") },
+                placeholder = { Text("Any additional details...") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                maxLines = 3
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    val entry = CycleEntry(
+                        id = existingId ?: 0,
+                        flow = selectedFlow,
+                        symptoms = CycleSymptom.encode(selectedSymptoms),
+                        notes = notes.trim(),
+                        timestamp = timestamp
+                    )
+                    if (isEditMode && existingId != null) {
+                        viewModel.updateCycleEntry(entry)
+                    } else {
+                        viewModel.addCycleEntry(entry)
+                    }
+                    viewModel.clearEditingState()
+                    onNavigateBack()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (isEditMode) "Update Entry" else "Save Entry")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
@@ -40,8 +40,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.MealWithDetails
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
@@ -52,6 +54,7 @@ import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
 import com.privatehealthjournal.ui.components.BloodPressureCard
 import com.privatehealthjournal.ui.components.CholesterolCard
+import com.privatehealthjournal.ui.components.CycleEntryCard
 import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
@@ -80,7 +83,8 @@ fun CalendarScreen(
     onEditCholesterol: (Long) -> Unit = {},
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
-    onEditBloodGlucose: (Long) -> Unit = {}
+    onEditBloodGlucose: (Long) -> Unit = {},
+    onEditCycleEntry: (Long) -> Unit = {}
 ) {
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
@@ -91,6 +95,8 @@ fun CalendarScreen(
     val allWeight by viewModel.allWeightEntries.collectAsState()
     val allSpO2 by viewModel.allSpO2Entries.collectAsState()
     val allBloodGlucose by viewModel.allBloodGlucoseEntries.collectAsState()
+    val allCycleEntries by viewModel.allCycleEntries.collectAsState()
+    val showCycleTracking by viewModel.showCycleTracking.collectAsState()
 
     var currentMonth by remember { mutableStateOf(YearMonth.now()) }
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
@@ -98,7 +104,7 @@ fun CalendarScreen(
     val zone = ZoneId.systemDefault()
 
     // Group entries by date
-    val entriesByDate = remember(allMeals, allSymptoms, allMedications, allOtherEntries, allBloodPressure, allCholesterol, allWeight, allSpO2, allBloodGlucose) {
+    val entriesByDate = remember(allMeals, allSymptoms, allMedications, allOtherEntries, allBloodPressure, allCholesterol, allWeight, allSpO2, allBloodGlucose, allCycleEntries, showCycleTracking) {
         val map = mutableMapOf<LocalDate, MutableList<CalendarEntry>>()
 
         allMeals.forEach { meal ->
@@ -137,8 +143,19 @@ fun CalendarScreen(
             val date = Instant.ofEpochMilli(bg.timestamp).atZone(zone).toLocalDate()
             map.getOrPut(date) { mutableListOf() }.add(CalendarEntry.BloodGlucose(bg))
         }
+        if (showCycleTracking) {
+            allCycleEntries.forEach { cycle ->
+                val date = Instant.ofEpochMilli(cycle.timestamp).atZone(zone).toLocalDate()
+                map.getOrPut(date) { mutableListOf() }.add(CalendarEntry.Cycle(cycle))
+            }
+        }
 
         map
+    }
+
+    val cycleDates = remember(allCycleEntries, showCycleTracking) {
+        if (!showCycleTracking) emptySet()
+        else allCycleEntries.map { Instant.ofEpochMilli(it.timestamp).atZone(zone).toLocalDate() }.toSet()
     }
 
     val selectedEntries = entriesByDate[selectedDate]
@@ -153,6 +170,7 @@ fun CalendarScreen(
                 is CalendarEntry.Weight -> it.entry.timestamp
                 is CalendarEntry.SpO2 -> it.entry.timestamp
                 is CalendarEntry.BloodGlucose -> it.entry.timestamp
+                is CalendarEntry.Cycle -> it.entry.timestamp
             }
         }
         ?: emptyList()
@@ -205,6 +223,7 @@ fun CalendarScreen(
                 yearMonth = currentMonth,
                 selectedDate = selectedDate,
                 datesWithEntries = entriesByDate.keys,
+                cycleDates = cycleDates,
                 onDateSelected = { selectedDate = it }
             )
 
@@ -281,6 +300,11 @@ fun CalendarScreen(
                                 onDelete = { viewModel.deleteBloodGlucose(entry.entry) },
                                 onEdit = { onEditBloodGlucose(entry.entry.id) }
                             )
+                            is CalendarEntry.Cycle -> CycleEntryCard(
+                                entry = entry.entry,
+                                onDelete = { viewModel.deleteCycleEntry(entry.entry) },
+                                onEdit = { onEditCycleEntry(entry.entry.id) }
+                            )
                         }
                     }
                 }
@@ -345,6 +369,7 @@ private fun CalendarGrid(
     yearMonth: YearMonth,
     selectedDate: LocalDate,
     datesWithEntries: Set<LocalDate>,
+    cycleDates: Set<LocalDate> = emptySet(),
     onDateSelected: (LocalDate) -> Unit
 ) {
     val firstOfMonth = yearMonth.atDay(1)
@@ -363,6 +388,7 @@ private fun CalendarGrid(
                         val date = yearMonth.atDay(dayIndex)
                         val isSelected = date == selectedDate
                         val hasEntries = date in datesWithEntries
+                        val hasCycleEntry = date in cycleDates
                         val isToday = date == LocalDate.now()
 
                         CalendarDayCell(
@@ -370,6 +396,7 @@ private fun CalendarGrid(
                             isSelected = isSelected,
                             isToday = isToday,
                             hasEntries = hasEntries,
+                            hasCycleEntry = hasCycleEntry,
                             onClick = { onDateSelected(date) },
                             modifier = Modifier.weight(1f)
                         )
@@ -388,6 +415,7 @@ private fun CalendarDayCell(
     isSelected: Boolean,
     isToday: Boolean,
     hasEntries: Boolean,
+    hasCycleEntry: Boolean = false,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -430,6 +458,17 @@ private fun CalendarDayCell(
                         )
                 )
             }
+            if (hasCycleEntry) {
+                Box(
+                    modifier = Modifier
+                        .size(4.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) MaterialTheme.colorScheme.onPrimary
+                            else Color(0xFFE91E63)
+                        )
+                )
+            }
         }
     }
 }
@@ -444,4 +483,5 @@ private sealed class CalendarEntry {
     data class Weight(val entry: WeightEntry) : CalendarEntry()
     data class SpO2(val entry: SpO2Entry) : CalendarEntry()
     data class BloodGlucose(val entry: BloodGlucoseEntry) : CalendarEntry()
+    data class Cycle(val entry: CycleEntry) : CalendarEntry()
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
@@ -57,10 +57,8 @@ data class PeriodGroup(
 ) {
     val durationDays: Int = ChronoUnit.DAYS.between(start, end).toInt() + 1
     val dominantFlow: FlowIntensity = entries
-        .groupingBy { it.flow }
-        .eachCount()
-        .maxByOrNull { it.value }
-        ?.key ?: FlowIntensity.MEDIUM
+        .maxOfOrNull { it.flow.ordinal }
+        ?.let { FlowIntensity.entries[it] } ?: FlowIntensity.MEDIUM
     val allSymptoms: Set<CycleSymptom> = entries
         .flatMap { CycleSymptom.decode(it.symptoms) }
         .toSet()

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
@@ -1,0 +1,330 @@
+package com.privatehealthjournal.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.CycleEntry
+import com.privatehealthjournal.data.entity.CycleSymptom
+import com.privatehealthjournal.data.entity.FlowIntensity
+import com.privatehealthjournal.viewmodel.LogViewModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+private val CycleRose = Color(0xFFE91E63)
+
+data class PeriodGroup(
+    val entries: List<CycleEntry>,
+    val start: LocalDate,
+    val end: LocalDate
+) {
+    val durationDays: Int = ChronoUnit.DAYS.between(start, end).toInt() + 1
+    val dominantFlow: FlowIntensity = entries
+        .groupingBy { it.flow }
+        .eachCount()
+        .maxByOrNull { it.value }
+        ?.key ?: FlowIntensity.MEDIUM
+    val allSymptoms: Set<CycleSymptom> = entries
+        .flatMap { CycleSymptom.decode(it.symptoms) }
+        .toSet()
+}
+
+private fun groupIntoPeriods(
+    entries: List<CycleEntry>,
+    zone: ZoneId = ZoneId.systemDefault()
+): List<PeriodGroup> {
+    if (entries.isEmpty()) return emptyList()
+    val sorted = entries.sortedBy { it.timestamp }
+    val groups = mutableListOf<MutableList<CycleEntry>>()
+    var current = mutableListOf(sorted.first())
+    for (i in 1 until sorted.size) {
+        val prevDate = Instant.ofEpochMilli(sorted[i - 1].timestamp).atZone(zone).toLocalDate()
+        val currDate = Instant.ofEpochMilli(sorted[i].timestamp).atZone(zone).toLocalDate()
+        if (ChronoUnit.DAYS.between(prevDate, currDate) <= 2) {
+            current.add(sorted[i])
+        } else {
+            groups.add(current)
+            current = mutableListOf(sorted[i])
+        }
+    }
+    groups.add(current)
+    return groups.map { group ->
+        val dates = group.map { Instant.ofEpochMilli(it.timestamp).atZone(zone).toLocalDate() }
+        PeriodGroup(entries = group, start = dates.min(), end = dates.max())
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CycleTrackingScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    onAddEntry: () -> Unit,
+    onEditEntry: (Long) -> Unit
+) {
+    val allCycleEntries by viewModel.allCycleEntries.collectAsState()
+
+    val periods = remember(allCycleEntries) {
+        groupIntoPeriods(allCycleEntries).sortedByDescending { it.start }
+    }
+
+    val avgCycleLength: Int? = remember(periods) {
+        if (periods.size < 2) null
+        else {
+            val sortedByStart = periods.sortedBy { it.start }
+            val gaps = sortedByStart.zipWithNext { a, b ->
+                ChronoUnit.DAYS.between(a.start, b.start).toInt()
+            }
+            gaps.average().toInt()
+        }
+    }
+
+    val avgPeriodDuration: Int? = remember(periods) {
+        if (periods.isEmpty()) null
+        else periods.map { it.durationDays }.average().toInt()
+    }
+
+    val predictedNext: LocalDate? = remember(periods, avgCycleLength) {
+        if (periods.isEmpty() || avgCycleLength == null) null
+        else periods.maxByOrNull { it.start }?.start?.plusDays(avgCycleLength.toLong())
+    }
+
+    val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Cycle Tracking", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddEntry,
+                containerColor = CycleRose,
+                contentColor = Color.White
+            ) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "Log Period")
+            }
+        }
+    ) { paddingValues ->
+        if (allCycleEntries.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription = null,
+                    tint = CycleRose.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(8.dp)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "No cycle entries yet",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+                Text(
+                    text = "Tap + to log your first period day",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                item { Spacer(modifier = Modifier.height(4.dp)) }
+
+                // Stats card
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Cycle Summary",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = CycleRose
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            val lastPeriod = periods.firstOrNull()
+                            if (lastPeriod != null) {
+                                StatRow(
+                                    label = "Last period",
+                                    value = if (lastPeriod.start == lastPeriod.end) {
+                                        lastPeriod.start.format(dateFormatter)
+                                    } else {
+                                        "${lastPeriod.start.format(dateFormatter)} – ${lastPeriod.end.format(dateFormatter)} (${lastPeriod.durationDays}d)"
+                                    }
+                                )
+                            }
+                            avgPeriodDuration?.let {
+                                StatRow(label = "Avg period length", value = "$it days")
+                            }
+                            avgCycleLength?.let {
+                                StatRow(label = "Avg cycle length", value = "$it days")
+                            }
+                            predictedNext?.let {
+                                StatRow(label = "Next period (est.)", value = "~${it.format(dateFormatter)}")
+                            }
+                        }
+                    }
+                }
+
+                item {
+                    Text(
+                        text = "Period History",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+
+                items(periods) { period ->
+                    PeriodCard(
+                        period = period,
+                        dateFormatter = dateFormatter,
+                        onEditEntry = onEditEntry
+                    )
+                }
+
+                item { Spacer(modifier = Modifier.height(80.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PeriodCard(
+    period: PeriodGroup,
+    dateFormatter: DateTimeFormatter,
+    onEditEntry: (Long) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = if (period.start == period.end) {
+                        period.start.format(dateFormatter)
+                    } else {
+                        "${period.start.format(dateFormatter)} – ${period.end.format(dateFormatter)}"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "${period.durationDays} day${if (period.durationDays != 1) "s" else ""}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = period.dominantFlow.displayLabel + " flow",
+                style = MaterialTheme.typography.bodyMedium,
+                color = CycleRose
+            )
+            if (period.allSymptoms.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    period.allSymptoms.forEach { symptom ->
+                        SuggestionChip(
+                            onClick = {},
+                            label = { Text(symptom.displayLabel, style = MaterialTheme.typography.labelSmall) },
+                            colors = SuggestionChipDefaults.suggestionChipColors(
+                                containerColor = CycleRose.copy(alpha = 0.12f)
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.MealWithDetails
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
@@ -44,6 +45,7 @@ import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
 import com.privatehealthjournal.ui.components.BloodPressureCard
 import com.privatehealthjournal.ui.components.CholesterolCard
+import com.privatehealthjournal.ui.components.CycleEntryCard
 import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
@@ -57,7 +59,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 enum class FilterType {
-    ALL, MEALS, SYMPTOMS, OTHER, MEDICATIONS, BIOMETRICS
+    ALL, MEALS, SYMPTOMS, OTHER, MEDICATIONS, BIOMETRICS, CYCLE
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -73,7 +75,8 @@ fun HistoryScreen(
     onEditCholesterol: (Long) -> Unit = {},
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
-    onEditBloodGlucose: (Long) -> Unit = {}
+    onEditBloodGlucose: (Long) -> Unit = {},
+    onEditCycleEntry: (Long) -> Unit = {}
 ) {
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
@@ -84,6 +87,8 @@ fun HistoryScreen(
     val allWeight by viewModel.allWeightEntries.collectAsState()
     val allSpO2 by viewModel.allSpO2Entries.collectAsState()
     val allBloodGlucose by viewModel.allBloodGlucoseEntries.collectAsState()
+    val allCycleEntries by viewModel.allCycleEntries.collectAsState()
+    val showCycleTracking by viewModel.showCycleTracking.collectAsState()
     var filterType by remember { mutableStateOf(FilterType.ALL) }
 
     Scaffold(
@@ -151,6 +156,13 @@ fun HistoryScreen(
                     onClick = { filterType = FilterType.BIOMETRICS },
                     label = { Text("Biometrics") }
                 )
+                if (showCycleTracking) {
+                    FilterChip(
+                        selected = filterType == FilterType.CYCLE,
+                        onClick = { filterType = FilterType.CYCLE },
+                        label = { Text("Cycle") }
+                    )
+                }
             }
 
             val filteredEntries = when (filterType) {
@@ -163,7 +175,8 @@ fun HistoryScreen(
                             allCholesterol.map { HistoryEntry.Cholesterol(it) } +
                             allWeight.map { HistoryEntry.Weight(it) } +
                             allSpO2.map { HistoryEntry.SpO2(it) } +
-                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) })
+                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
+                            (if (showCycleTracking) allCycleEntries.map { HistoryEntry.Cycle(it) } else emptyList()))
                         .sortedByDescending { it.timestamp }
                 }
                 FilterType.MEALS -> allMeals.map { HistoryEntry.Meal(it) }
@@ -182,6 +195,8 @@ fun HistoryScreen(
                             allBloodGlucose.map { HistoryEntry.BloodGlucose(it) })
                         .sortedByDescending { it.timestamp }
                 }
+                FilterType.CYCLE -> allCycleEntries.map { HistoryEntry.Cycle(it) }
+                    .sortedByDescending { it.timestamp }
             }
 
             if (filteredEntries.isEmpty()) {
@@ -291,6 +306,11 @@ fun HistoryScreen(
                                     onDelete = { viewModel.deleteBloodGlucose(entry.entry) },
                                     onEdit = { onEditBloodGlucose(entry.entry.id) }
                                 )
+                                is HistoryEntry.Cycle -> CycleEntryCard(
+                                    entry = entry.entry,
+                                    onDelete = { viewModel.deleteCycleEntry(entry.entry) },
+                                    onEdit = { onEditCycleEntry(entry.entry.id) }
+                                )
                             }
                         }
                     }
@@ -336,6 +356,10 @@ private sealed class HistoryEntry {
     }
 
     data class BloodGlucose(val entry: BloodGlucoseEntry) : HistoryEntry() {
+        override val timestamp: Long = entry.timestamp
+    }
+
+    data class Cycle(val entry: CycleEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.MonitorHeart
@@ -51,8 +52,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.data.entity.CholesterolEntry
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.MealWithDetails
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
@@ -63,6 +66,7 @@ import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
 import com.privatehealthjournal.ui.components.BloodPressureCard
 import com.privatehealthjournal.ui.components.CholesterolCard
+import com.privatehealthjournal.ui.components.CycleEntryCard
 import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
@@ -102,7 +106,9 @@ fun HomeScreen(
     onEditSpO2: (Long) -> Unit = {},
     onEditBloodGlucose: (Long) -> Unit = {},
     onViewMedicationSets: () -> Unit = {},
-    onViewMealBudget: () -> Unit = {}
+    onViewMealBudget: () -> Unit = {},
+    onViewCycleTracking: () -> Unit = {},
+    onEditCycleEntry: (Long) -> Unit = {}
 ) {
     val recentMeals by viewModel.recentMeals.collectAsState()
     val recentSymptoms by viewModel.recentSymptomEntries.collectAsState()
@@ -113,6 +119,8 @@ fun HomeScreen(
     val recentWeight by viewModel.recentWeightEntries.collectAsState()
     val recentSpO2 by viewModel.recentSpO2Entries.collectAsState()
     val recentBloodGlucose by viewModel.recentBloodGlucoseEntries.collectAsState()
+    val recentCycleEntries by viewModel.recentCycleEntries.collectAsState()
+    val showCycleTracking by viewModel.showCycleTracking.collectAsState()
 
     var medsMenuExpanded by remember { mutableStateOf(false) }
     var biometricsMenuExpanded by remember { mutableStateOf(false) }
@@ -398,6 +406,24 @@ fun HomeScreen(
                         )
                     }
                 }
+
+                // Cycle tracking button (hidden when showCycleTracking is false)
+                if (showCycleTracking) {
+                    Button(
+                        onClick = { onViewCycleTracking() },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFE91E63)
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Favorite,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Cycle")
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -414,7 +440,8 @@ fun HomeScreen(
                 recentMedications.isEmpty() && recentOtherEntries.isEmpty() &&
                 recentBloodPressure.isEmpty() && recentCholesterol.isEmpty() &&
                 recentWeight.isEmpty() && recentSpO2.isEmpty() &&
-                recentBloodGlucose.isEmpty()
+                recentBloodGlucose.isEmpty() &&
+                (!showCycleTracking || recentCycleEntries.isEmpty())
 
             if (allEmpty) {
                 Column(
@@ -450,7 +477,8 @@ fun HomeScreen(
                     recentCholesterol.map { EntryItem.Cholesterol(it) } +
                     recentWeight.map { EntryItem.Weight(it) } +
                     recentSpO2.map { EntryItem.SpO2(it) } +
-                    recentBloodGlucose.map { EntryItem.BloodGlucose(it) }
+                    recentBloodGlucose.map { EntryItem.BloodGlucose(it) } +
+                    (if (showCycleTracking) recentCycleEntries.map { EntryItem.Cycle(it) } else emptyList())
                 )
                     .sortedByDescending { it.timestamp }
                     .take(10)
@@ -547,6 +575,11 @@ fun HomeScreen(
                                     onDelete = { viewModel.deleteBloodGlucose(item.entry) },
                                     onEdit = { onEditBloodGlucose(item.entry.id) }
                                 )
+                                is EntryItem.Cycle -> CycleEntryCard(
+                                    entry = item.entry,
+                                    onDelete = { viewModel.deleteCycleEntry(item.entry) },
+                                    onEdit = { onEditCycleEntry(item.entry.id) }
+                                )
                             }
                         }
                     }
@@ -584,6 +617,9 @@ private sealed class EntryItem {
         override val timestamp: Long = entry.timestamp
     }
     data class BloodGlucose(val entry: BloodGlucoseEntry) : EntryItem() {
+        override val timestamp: Long = entry.timestamp
+    }
+    data class Cycle(val entry: CycleEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
@@ -3,7 +3,9 @@ package com.privatehealthjournal.ui.screens
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,6 +31,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -61,6 +64,7 @@ fun SettingsScreen(
     val allMedications by viewModel.allMedications.collectAsState()
     val allOtherEntries by viewModel.allOtherEntries.collectAsState()
     val dailyBudget by viewModel.dailyBudget.collectAsState()
+    val showCycleTracking by viewModel.showCycleTracking.collectAsState()
 
     var budgetText by remember { mutableStateOf("") }
 
@@ -199,6 +203,47 @@ fun SettingsScreen(
                 enabled = budgetText.toIntOrNull() != null || (budgetText.isEmpty() && dailyBudget != null)
             ) {
                 Text(if (budgetText.isEmpty() && dailyBudget != null) "Clear Budget" else "Save Budget")
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Display",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Cycle Tracking",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Text(
+                            text = "Show cycle/period tracking features",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = showCycleTracking,
+                        onCheckedChange = { viewModel.setShowCycleTracking(it) }
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
@@ -22,6 +22,7 @@ import com.privatehealthjournal.data.entity.MedicationSetReminder
 import com.privatehealthjournal.data.entity.MedicationSetWithItems
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.OtherEntryType
+import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.GlucoseMealContext
 import com.privatehealthjournal.data.entity.GlucoseUnit
 import com.privatehealthjournal.data.entity.SpO2Entry
@@ -29,7 +30,9 @@ import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.Tag
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.data.entity.WeightUnit
+import com.privatehealthjournal.data.preferences.AppPreferences
 import com.privatehealthjournal.data.preferences.BudgetPreferences
+import com.privatehealthjournal.data.preferences.appDataStore
 import com.privatehealthjournal.data.repository.LogRepository
 import com.privatehealthjournal.notification.ReminderScheduler
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,6 +79,9 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     val moodDescriptions: StateFlow<List<String>>
     val otherCategories: StateFlow<List<String>>
     val dailyBudget: StateFlow<Int?>
+    val allCycleEntries: StateFlow<List<CycleEntry>>
+    val recentCycleEntries: StateFlow<List<CycleEntry>>
+    val showCycleTracking: StateFlow<Boolean>
 
     init {
         val database = AppDatabase.getDatabase(application)
@@ -92,7 +98,8 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             database.bloodGlucoseDao(),
             database.medicationSetDao(),
             database.medicationSetReminderDao(),
-            database.medicationSetLogDao()
+            database.medicationSetLogDao(),
+            database.cycleEntryDao()
         )
 
         allMeals = repository.allMeals
@@ -194,6 +201,15 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
 
         dailyBudget = BudgetPreferences.getDailyBudget(application)
             .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+        allCycleEntries = repository.allCycleEntries
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        recentCycleEntries = repository.getRecentCycleEntries(5)
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        showCycleTracking = AppPreferences.getShowCycleTracking(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, true)
     }
 
     fun addMeal(
@@ -217,6 +233,24 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
                 BudgetPreferences.setDailyBudget(getApplication(), budget)
             }
         }
+    }
+
+    fun setShowCycleTracking(show: Boolean) {
+        viewModelScope.launch {
+            AppPreferences.setShowCycleTracking(getApplication(), show)
+        }
+    }
+
+    fun addCycleEntry(entry: CycleEntry) {
+        viewModelScope.launch { repository.insertCycleEntry(entry) }
+    }
+
+    fun updateCycleEntry(entry: CycleEntry) {
+        viewModelScope.launch { repository.updateCycleEntry(entry) }
+    }
+
+    fun deleteCycleEntry(entry: CycleEntry) {
+        viewModelScope.launch { repository.deleteCycleEntry(entry) }
     }
 
     fun addSymptom(
@@ -540,6 +574,9 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     private val _editingMedicationSet = MutableStateFlow<MedicationSetWithItems?>(null)
     val editingMedicationSet: StateFlow<MedicationSetWithItems?> = _editingMedicationSet.asStateFlow()
 
+    private val _editingCycleEntry = MutableStateFlow<CycleEntry?>(null)
+    val editingCycleEntry: StateFlow<CycleEntry?> = _editingCycleEntry.asStateFlow()
+
     fun loadSymptomForEditing(id: Long) {
         viewModelScope.launch {
             _editingSymptom.value = repository.getSymptomById(id)
@@ -606,6 +643,12 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun loadCycleEntryForEditing(id: Long) {
+        viewModelScope.launch {
+            _editingCycleEntry.value = repository.getCycleEntryById(id)
+        }
+    }
+
     fun clearEditingState() {
         _editingSymptom.value = null
         _editingBowelMovement.value = null
@@ -618,6 +661,7 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         _editingSpO2.value = null
         _editingBloodGlucose.value = null
         _editingMedicationSet.value = null
+        _editingCycleEntry.value = null
     }
 
     // Medication Set methods
@@ -702,7 +746,8 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
                     weightEntries = allWeightEntries.value,
                     spO2Entries = allSpO2Entries.value,
                     bloodGlucoseEntries = allBloodGlucoseEntries.value,
-                    medicationSets = allMedicationSets.value
+                    medicationSets = allMedicationSets.value,
+                    cycleEntries = allCycleEntries.value
                 )
                 getApplication<Application>().contentResolver.openOutputStream(uri)?.use { stream ->
                     stream.write(json.toByteArray())

--- a/app/src/test/java/com/privatehealthjournal/data/export/DataExporterTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/data/export/DataExporterTest.kt
@@ -34,7 +34,7 @@ class DataExporterTest {
         )
 
         val result = gson.fromJson(json, ExportData::class.java)
-        assertThat(result.version).isEqualTo(3)
+        assertThat(result.version).isEqualTo(4)
         assertThat(result.exportedAt).isGreaterThan(0L)
     }
 

--- a/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
@@ -12,6 +12,7 @@ import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.SpO2Dao
 import com.privatehealthjournal.data.dao.SymptomEntryDao
+import com.privatehealthjournal.data.dao.CycleEntryDao
 import com.privatehealthjournal.data.dao.WeightDao
 import com.privatehealthjournal.data.entity.MealType
 import com.privatehealthjournal.data.repository.LogRepository
@@ -41,6 +42,7 @@ class LogRepositoryTest {
     private lateinit var medicationSetDao: MedicationSetDao
     private lateinit var medicationSetReminderDao: MedicationSetReminderDao
     private lateinit var medicationSetLogDao: MedicationSetLogDao
+    private lateinit var cycleEntryDao: CycleEntryDao
     private lateinit var repository: LogRepository
 
     @Before
@@ -58,6 +60,8 @@ class LogRepositoryTest {
         medicationSetDao = mockk(relaxed = true)
         medicationSetReminderDao = mockk(relaxed = true)
         medicationSetLogDao = mockk(relaxed = true)
+        cycleEntryDao = mockk(relaxed = true)
+        every { cycleEntryDao.getAllCycleEntries() } returns flowOf(emptyList())
 
         every { mealDao.getAllMealsWithDetails() } returns flowOf(emptyList())
         every { mealDao.getAllTags() } returns flowOf(emptyList())
@@ -87,7 +91,8 @@ class LogRepositoryTest {
             bloodGlucoseDao,
             medicationSetDao,
             medicationSetReminderDao,
-            medicationSetLogDao
+            medicationSetLogDao,
+            cycleEntryDao
         )
     }
 


### PR DESCRIPTION
Log period days with flow intensity (spotting/light/medium/heavy) and cycle symptoms (cramps, bloating, etc). CycleTrackingScreen hub shows last period, avg cycle/period length, and predicted next period.

Entries appear in home feed, history (Cycle filter), and calendar (pink indicator dots). Settings toggle hides the feature for users who don't need it. Backed by Room DB v13 migration and included in JSON export/import.

Closes #15 