### PR TITLE
feat: add step counting (sensor, Health Connect, manual)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,9 @@ dependencies {
     // Charting - Vico
     implementation("com.patrykandpatrick.vico:compose-m3:1.15.0")
 
+    // Health Connect
+    implementation("androidx.health.connect:connect-client:1.1.0-alpha07")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -30,6 +30,7 @@ import com.privatehealthjournal.ui.screens.AddMedicationScreen
 import com.privatehealthjournal.ui.screens.AddMedicationSetScreen
 import com.privatehealthjournal.ui.screens.AddOtherEntryScreen
 import com.privatehealthjournal.ui.screens.AddSpO2Screen
+import com.privatehealthjournal.ui.screens.AddStepCountScreen
 import com.privatehealthjournal.ui.screens.AddSymptomScreen
 import com.privatehealthjournal.ui.screens.AddWeightScreen
 import com.privatehealthjournal.ui.screens.BiometricsChartScreen
@@ -41,8 +42,18 @@ import com.privatehealthjournal.ui.screens.MealBudgetScreen
 import com.privatehealthjournal.ui.screens.MedicationSetsScreen
 import com.privatehealthjournal.ui.screens.SettingsScreen
 import com.privatehealthjournal.notification.ReminderBroadcastReceiver
+import com.privatehealthjournal.sensor.StepSync
 import com.privatehealthjournal.ui.theme.PrivateHealthJournalTheme
 import com.privatehealthjournal.viewmodel.LogViewModel
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.lifecycleScope
+import com.privatehealthjournal.data.AppDatabase
+import com.privatehealthjournal.data.repository.LogRepository
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -50,10 +61,23 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.RequestPermission()
     ) { _: Boolean -> }
 
+    private lateinit var stepSync: StepSync
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         createNotificationChannel()
         requestNotificationPermission()
+
+        val db = AppDatabase.getDatabase(applicationContext)
+        val syncRepo = LogRepository(
+            db.mealDao(), db.symptomEntryDao(), db.bowelMovementDao(),
+            db.medicationDao(), db.otherEntryDao(), db.bloodPressureDao(),
+            db.cholesterolDao(), db.weightDao(), db.spO2Dao(),
+            db.bloodGlucoseDao(), db.medicationSetDao(),
+            db.medicationSetReminderDao(), db.medicationSetLogDao(),
+            db.cycleEntryDao(), db.stepCountDao()
+        )
+        stepSync = StepSync.create(applicationContext, syncRepo)
 
         val navigateTo = intent?.getStringExtra("navigate_to")
 
@@ -65,6 +89,17 @@ class MainActivity : ComponentActivity() {
                 ) {
                     val navController = rememberNavController()
                     val viewModel: LogViewModel = viewModel()
+                    val lifecycleOwner = LocalLifecycleOwner.current
+
+                    DisposableEffect(lifecycleOwner) {
+                        val observer = LifecycleEventObserver { _, event ->
+                            if (event == Lifecycle.Event.ON_RESUME) {
+                                lifecycleScope.launch { stepSync.syncOnResume() }
+                            }
+                        }
+                        lifecycleOwner.lifecycle.addObserver(observer)
+                        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+                    }
 
                     LaunchedEffect(navigateTo) {
                         if (navigateTo != null) {
@@ -94,6 +129,7 @@ class MainActivity : ComponentActivity() {
                                 onAddWeight = { navController.navigate("add_weight") },
                                 onAddSpO2 = { navController.navigate("add_spo2") },
                                 onAddBloodGlucose = { navController.navigate("add_blood_glucose") },
+                                onAddStepCount = { navController.navigate("add_step_count") },
                                 onViewBiometricsChart = { navController.navigate("biometrics_chart") },
                                 onViewHistory = { navController.navigate("history") },
                                 onViewCalendar = { navController.navigate("calendar") },
@@ -107,6 +143,7 @@ class MainActivity : ComponentActivity() {
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
                                 onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
+                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") },
                                 onViewMedicationSets = { navController.navigate("medication_sets") },
                                 onViewMealBudget = { navController.navigate("meal_budget") },
                                 onViewCycleTracking = { navController.navigate("cycle_tracking") },
@@ -235,7 +272,8 @@ class MainActivity : ComponentActivity() {
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
                                 onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
+                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") },
+                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") }
                             )
                         }
                         composable("history") {
@@ -251,7 +289,8 @@ class MainActivity : ComponentActivity() {
                                 onEditWeight = { id -> navController.navigate("edit_weight/$id") },
                                 onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
                                 onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
+                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") },
+                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") }
                             )
                         }
                         composable("cycle_tracking") {
@@ -402,6 +441,23 @@ class MainActivity : ComponentActivity() {
                                 viewModel = viewModel,
                                 onNavigateBack = { navController.popBackStack() },
                                 editId = bloodGlucoseId
+                            )
+                        }
+                        composable("add_step_count") {
+                            AddStepCountScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() }
+                            )
+                        }
+                        composable(
+                            route = "edit_step_count/{stepCountId}",
+                            arguments = listOf(navArgument("stepCountId") { type = NavType.LongType })
+                        ) { backStackEntry ->
+                            val stepCountId = backStackEntry.arguments?.getLong("stepCountId")
+                            AddStepCountScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = { navController.popBackStack() },
+                                editId = stepCountId
                             )
                         }
                     }

--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -18,6 +18,7 @@ import com.privatehealthjournal.data.dao.MedicationSetLogDao
 import com.privatehealthjournal.data.dao.MedicationSetReminderDao
 import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.SpO2Dao
+import com.privatehealthjournal.data.dao.StepCountDao
 import com.privatehealthjournal.data.dao.SymptomEntryDao
 import com.privatehealthjournal.data.dao.WeightDao
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
@@ -35,6 +36,7 @@ import com.privatehealthjournal.data.entity.MedicationSetLog
 import com.privatehealthjournal.data.entity.MedicationSetReminder
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.Tag
 import com.privatehealthjournal.data.entity.WeightEntry
@@ -58,9 +60,10 @@ import com.privatehealthjournal.data.entity.WeightEntry
         MedicationSetItem::class,
         MedicationSetReminder::class,
         MedicationSetLog::class,
-        CycleEntry::class
+        CycleEntry::class,
+        StepCountEntry::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -78,6 +81,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun medicationSetReminderDao(): MedicationSetReminderDao
     abstract fun medicationSetLogDao(): MedicationSetLogDao
     abstract fun cycleEntryDao(): CycleEntryDao
+    abstract fun stepCountDao(): StepCountDao
 
     companion object {
         @Volatile
@@ -166,6 +170,22 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `step_count_entries` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `dateEpochDay` INTEGER NOT NULL,
+                        `steps` INTEGER NOT NULL,
+                        `source` TEXT NOT NULL,
+                        `notes` TEXT NOT NULL,
+                        `timestamp` INTEGER NOT NULL
+                    )
+                """.trimIndent())
+                database.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_step_count_entries_dateEpochDay` ON `step_count_entries` (`dateEpochDay`)")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -173,7 +193,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "private_health_journal_database"
                 )
-                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
+                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                     .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/privatehealthjournal/data/dao/StepCountDao.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/dao/StepCountDao.kt
@@ -1,0 +1,40 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.privatehealthjournal.data.entity.StepCountEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface StepCountDao {
+    @Query("SELECT * FROM step_count_entries ORDER BY dateEpochDay DESC")
+    fun getAllStepCountEntries(): Flow<List<StepCountEntry>>
+
+    @Query("SELECT * FROM step_count_entries ORDER BY dateEpochDay DESC LIMIT :limit")
+    fun getRecentStepCountEntries(limit: Int): Flow<List<StepCountEntry>>
+
+    @Query("SELECT * FROM step_count_entries WHERE id = :id")
+    suspend fun getById(id: Long): StepCountEntry?
+
+    @Query("SELECT * FROM step_count_entries WHERE dateEpochDay = :day LIMIT 1")
+    suspend fun getByEpochDay(day: Long): StepCountEntry?
+
+    @Insert
+    suspend fun insert(entry: StepCountEntry): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: StepCountEntry): Long
+
+    @Update
+    suspend fun update(entry: StepCountEntry)
+
+    @Delete
+    suspend fun delete(entry: StepCountEntry)
+
+    @Query("DELETE FROM step_count_entries WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/privatehealthjournal/data/entity/StepCountEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/StepCountEntry.kt
@@ -1,0 +1,21 @@
+package com.privatehealthjournal.data.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+enum class StepSource { SENSOR, HEALTH_CONNECT, MANUAL }
+
+@Entity(
+    tableName = "step_count_entries",
+    indices = [Index(value = ["dateEpochDay"], unique = true)]
+)
+data class StepCountEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val dateEpochDay: Long,
+    val steps: Int,
+    val source: StepSource,
+    val notes: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataExporter.kt
@@ -12,6 +12,7 @@ import com.privatehealthjournal.data.entity.MedicationSetReminder
 import com.privatehealthjournal.data.entity.MedicationSetWithItems
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.google.gson.GsonBuilder
@@ -34,7 +35,8 @@ object DataExporter {
         medicationSets: List<MedicationSetWithItems> = emptyList(),
         remindersBySetId: Map<Long, List<MedicationSetReminder>> = emptyMap(),
         logsBySetId: Map<Long, List<MedicationSetLog>> = emptyMap(),
-        cycleEntries: List<CycleEntry> = emptyList()
+        cycleEntries: List<CycleEntry> = emptyList(),
+        stepCountEntries: List<StepCountEntry> = emptyList()
     ): String {
         val exportData = ExportData(
             meals = meals.map { meal ->
@@ -152,6 +154,15 @@ object DataExporter {
                 ExportedCycleEntry(
                     flow = entry.flow.name,
                     symptoms = entry.symptoms,
+                    notes = entry.notes,
+                    timestamp = entry.timestamp
+                )
+            },
+            stepCountEntries = stepCountEntries.map { entry ->
+                ExportedStepCount(
+                    dateEpochDay = entry.dateEpochDay,
+                    steps = entry.steps,
+                    source = entry.source.name,
                     notes = entry.notes,
                     timestamp = entry.timestamp
                 )

--- a/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/DataImporter.kt
@@ -15,6 +15,8 @@ import com.privatehealthjournal.data.entity.OtherEntryType
 import com.privatehealthjournal.data.entity.GlucoseMealContext
 import com.privatehealthjournal.data.entity.GlucoseUnit
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
+import com.privatehealthjournal.data.entity.StepSource
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.data.entity.WeightUnit
@@ -44,6 +46,7 @@ object DataImporter {
             var medicationSetRemindersImported = 0
             var medicationSetLogsImported = 0
             var cycleEntriesImported = 0
+            var stepCountEntriesImported = 0
 
             // Import meals
             exportData.meals.forEach { meal ->
@@ -253,6 +256,25 @@ object DataImporter {
                 cycleEntriesImported++
             }
 
+            // Import step count entries (use upsert — restoring backup is trust-source, bypass merge)
+            exportData.stepCountEntries.forEach { entry ->
+                val source = try {
+                    StepSource.valueOf(entry.source)
+                } catch (e: IllegalArgumentException) {
+                    StepSource.MANUAL
+                }
+                repository.upsertStepCount(
+                    StepCountEntry(
+                        dateEpochDay = entry.dateEpochDay,
+                        steps = entry.steps,
+                        source = source,
+                        notes = entry.notes,
+                        timestamp = entry.timestamp
+                    )
+                )
+                stepCountEntriesImported++
+            }
+
             ImportResult.Success(
                 mealsImported = mealsImported,
                 symptomsImported = symptomsImported,
@@ -267,7 +289,8 @@ object DataImporter {
                 medicationSetsImported = medicationSetsImported,
                 medicationSetRemindersImported = medicationSetRemindersImported,
                 medicationSetLogsImported = medicationSetLogsImported,
-                cycleEntriesImported = cycleEntriesImported
+                cycleEntriesImported = cycleEntriesImported,
+                stepCountEntriesImported = stepCountEntriesImported
             )
         } catch (e: Exception) {
             ImportResult.Error("Failed to import: ${e.message}")
@@ -290,7 +313,8 @@ sealed class ImportResult {
         val medicationSetsImported: Int = 0,
         val medicationSetRemindersImported: Int = 0,
         val medicationSetLogsImported: Int = 0,
-        val cycleEntriesImported: Int = 0
+        val cycleEntriesImported: Int = 0,
+        val stepCountEntriesImported: Int = 0
     ) : ImportResult() {
         val totalImported: Int
             get() = mealsImported + symptomsImported + bowelMovementsImported +
@@ -298,7 +322,7 @@ sealed class ImportResult {
                     bloodPressureImported + cholesterolImported + weightImported + spO2Imported +
                     bloodGlucoseImported + medicationSetsImported +
                     medicationSetRemindersImported + medicationSetLogsImported +
-                    cycleEntriesImported
+                    cycleEntriesImported + stepCountEntriesImported
     }
 
     data class Error(val message: String) : ImportResult()

--- a/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/export/ExportData.kt
@@ -1,7 +1,7 @@
 package com.privatehealthjournal.data.export
 
 data class ExportData(
-    val version: Int = 5,
+    val version: Int = 6,
     val exportedAt: Long = System.currentTimeMillis(),
     val meals: List<ExportedMeal> = emptyList(),
     val symptoms: List<ExportedSymptom> = emptyList(),
@@ -14,7 +14,8 @@ data class ExportData(
     val spO2Entries: List<ExportedSpO2> = emptyList(),
     val bloodGlucoseEntries: List<ExportedBloodGlucose> = emptyList(),
     val medicationSets: List<ExportedMedicationSet> = emptyList(),
-    val cycleEntries: List<ExportedCycleEntry> = emptyList()
+    val cycleEntries: List<ExportedCycleEntry> = emptyList(),
+    val stepCountEntries: List<ExportedStepCount> = emptyList()
 )
 
 data class ExportedMeal(
@@ -121,6 +122,14 @@ data class ExportedMedicationSetLog(
 data class ExportedCycleEntry(
     val flow: String,
     val symptoms: String,
+    val notes: String,
+    val timestamp: Long
+)
+
+data class ExportedStepCount(
+    val dateEpochDay: Long,
+    val steps: Int,
+    val source: String,
     val notes: String,
     val timestamp: Long
 )

--- a/app/src/main/java/com/privatehealthjournal/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/preferences/AppPreferences.kt
@@ -13,11 +13,35 @@ val Context.appDataStore: DataStore<Preferences> by preferencesDataStore(name = 
 
 object AppPreferences {
     val SHOW_CYCLE_TRACKING = booleanPreferencesKey("show_cycle_tracking")
+    val SHOW_STEP_COUNTING = booleanPreferencesKey("show_step_counting")
+    val STEP_SENSOR_ENABLED = booleanPreferencesKey("step_sensor_enabled")
+    val HEALTH_CONNECT_ENABLED = booleanPreferencesKey("health_connect_enabled")
 
     fun getShowCycleTracking(context: Context): Flow<Boolean> =
         context.appDataStore.data.map { prefs -> prefs[SHOW_CYCLE_TRACKING] ?: true }
 
     suspend fun setShowCycleTracking(context: Context, show: Boolean) {
         context.appDataStore.edit { prefs -> prefs[SHOW_CYCLE_TRACKING] = show }
+    }
+
+    fun getShowStepCounting(context: Context): Flow<Boolean> =
+        context.appDataStore.data.map { prefs -> prefs[SHOW_STEP_COUNTING] ?: false }
+
+    suspend fun setShowStepCounting(context: Context, show: Boolean) {
+        context.appDataStore.edit { prefs -> prefs[SHOW_STEP_COUNTING] = show }
+    }
+
+    fun getStepSensorEnabled(context: Context): Flow<Boolean> =
+        context.appDataStore.data.map { prefs -> prefs[STEP_SENSOR_ENABLED] ?: false }
+
+    suspend fun setStepSensorEnabled(context: Context, enabled: Boolean) {
+        context.appDataStore.edit { prefs -> prefs[STEP_SENSOR_ENABLED] = enabled }
+    }
+
+    fun getHealthConnectEnabled(context: Context): Flow<Boolean> =
+        context.appDataStore.data.map { prefs -> prefs[HEALTH_CONNECT_ENABLED] ?: false }
+
+    suspend fun setHealthConnectEnabled(context: Context, enabled: Boolean) {
+        context.appDataStore.edit { prefs -> prefs[HEALTH_CONNECT_ENABLED] = enabled }
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/data/preferences/BudgetPreferences.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/preferences/BudgetPreferences.kt
@@ -13,6 +13,7 @@ val Context.budgetDataStore: DataStore<Preferences> by preferencesDataStore(name
 
 object BudgetPreferences {
     val DAILY_BUDGET = intPreferencesKey("daily_budget")
+    val STEPS_PER_POINT_CREDIT = intPreferencesKey("steps_per_point_credit")
 
     fun getDailyBudget(context: Context): Flow<Int?> =
         context.budgetDataStore.data.map { prefs -> prefs[DAILY_BUDGET] }
@@ -23,5 +24,16 @@ object BudgetPreferences {
 
     suspend fun clearDailyBudget(context: Context) {
         context.budgetDataStore.edit { prefs -> prefs.remove(DAILY_BUDGET) }
+    }
+
+    fun getStepsPerPointCredit(context: Context): Flow<Int?> =
+        context.budgetDataStore.data.map { prefs -> prefs[STEPS_PER_POINT_CREDIT] }
+
+    suspend fun setStepsPerPointCredit(context: Context, value: Int) {
+        context.budgetDataStore.edit { prefs -> prefs[STEPS_PER_POINT_CREDIT] = value }
+    }
+
+    suspend fun clearStepsPerPointCredit(context: Context) {
+        context.budgetDataStore.edit { prefs -> prefs.remove(STEPS_PER_POINT_CREDIT) }
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/data/preferences/StepPrefs.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/preferences/StepPrefs.kt
@@ -1,0 +1,37 @@
+package com.privatehealthjournal.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+val Context.stepDataStore: DataStore<Preferences> by preferencesDataStore(name = "step_prefs")
+
+object StepPrefs {
+    private val LAST_CUMULATIVE_COUNT = longPreferencesKey("last_cumulative_count")
+    private val LAST_READING_EPOCH_DAY = longPreferencesKey("last_reading_epoch_day")
+    private val HC_LAST_SYNC_EPOCH_DAY = longPreferencesKey("hc_last_sync_epoch_day")
+
+    suspend fun getLastCumulative(context: Context): Long? =
+        context.stepDataStore.data.first()[LAST_CUMULATIVE_COUNT]
+
+    suspend fun getLastReadingEpochDay(context: Context): Long? =
+        context.stepDataStore.data.first()[LAST_READING_EPOCH_DAY]
+
+    suspend fun setLastReading(context: Context, cumulative: Long, epochDay: Long) {
+        context.stepDataStore.edit { prefs ->
+            prefs[LAST_CUMULATIVE_COUNT] = cumulative
+            prefs[LAST_READING_EPOCH_DAY] = epochDay
+        }
+    }
+
+    suspend fun getHcLastSyncEpochDay(context: Context): Long? =
+        context.stepDataStore.data.first()[HC_LAST_SYNC_EPOCH_DAY]
+
+    suspend fun setHcLastSyncEpochDay(context: Context, epochDay: Long) {
+        context.stepDataStore.edit { prefs -> prefs[HC_LAST_SYNC_EPOCH_DAY] = epochDay }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
@@ -12,6 +12,7 @@ import com.privatehealthjournal.data.dao.MedicationSetLogDao
 import com.privatehealthjournal.data.dao.MedicationSetReminderDao
 import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.SpO2Dao
+import com.privatehealthjournal.data.dao.StepCountDao
 import com.privatehealthjournal.data.dao.SymptomEntryDao
 import com.privatehealthjournal.data.dao.WeightDao
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
@@ -30,6 +31,8 @@ import com.privatehealthjournal.data.entity.MedicationSetWithItems
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.OtherEntryType
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
+import com.privatehealthjournal.data.entity.StepSource
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.Tag
 import com.privatehealthjournal.data.entity.WeightEntry
@@ -49,7 +52,8 @@ class LogRepository(
     private val medicationSetDao: MedicationSetDao,
     private val medicationSetReminderDao: MedicationSetReminderDao,
     private val medicationSetLogDao: MedicationSetLogDao,
-    private val cycleEntryDao: CycleEntryDao
+    private val cycleEntryDao: CycleEntryDao,
+    private val stepCountDao: StepCountDao
 ) {
     val allMeals: Flow<List<MealWithDetails>> = mealDao.getAllMealsWithDetails()
     val allSymptomEntries: Flow<List<SymptomEntry>> = symptomEntryDao.getAllSymptomEntries()
@@ -68,6 +72,7 @@ class LogRepository(
     val allFoodNames: Flow<List<String>> = mealDao.getAllFoodNames()
     val allSymptomNames: Flow<List<String>> = symptomEntryDao.getAllSymptomNames()
     val allCycleEntries: Flow<List<CycleEntry>> = cycleEntryDao.getAllCycleEntries()
+    val allStepCountEntries: Flow<List<StepCountEntry>> = stepCountDao.getAllStepCountEntries()
     fun getDistinctOtherSubTypes(type: OtherEntryType): Flow<List<String>> =
         otherEntryDao.getDistinctSubTypes(type)
 
@@ -113,6 +118,10 @@ class LogRepository(
 
     fun getRecentCycleEntries(limit: Int = 5): Flow<List<CycleEntry>> {
         return cycleEntryDao.getRecentCycleEntries(limit)
+    }
+
+    fun getRecentStepCountEntries(limit: Int = 5): Flow<List<StepCountEntry>> {
+        return stepCountDao.getRecentStepCountEntries(limit)
     }
 
     suspend fun insertMeal(
@@ -366,6 +375,42 @@ class LogRepository(
     suspend fun updateCycleEntry(entry: CycleEntry) = cycleEntryDao.update(entry)
     suspend fun deleteCycleEntry(entry: CycleEntry) = cycleEntryDao.delete(entry)
     suspend fun getCycleEntryById(id: Long): CycleEntry? = cycleEntryDao.getById(id)
+
+    // Step Count methods
+    suspend fun insertStepCount(entry: StepCountEntry): Long = stepCountDao.insert(entry)
+    suspend fun updateStepCount(entry: StepCountEntry) = stepCountDao.update(entry)
+    suspend fun deleteStepCount(entry: StepCountEntry) = stepCountDao.delete(entry)
+    suspend fun deleteStepCountById(id: Long) = stepCountDao.deleteById(id)
+    suspend fun getStepCountById(id: Long): StepCountEntry? = stepCountDao.getById(id)
+    suspend fun getStepCountByEpochDay(day: Long): StepCountEntry? = stepCountDao.getByEpochDay(day)
+
+    /**
+     * Merge rule: manual entries are sticky; auto sources overwrite each other freely.
+     * Returns the row id (existing or new).
+     */
+    suspend fun recordStepCount(
+        dateEpochDay: Long,
+        steps: Int,
+        source: StepSource,
+        notes: String = "",
+        timestamp: Long = System.currentTimeMillis()
+    ): Long {
+        val existing = stepCountDao.getByEpochDay(dateEpochDay)
+        if (existing != null && existing.source == StepSource.MANUAL && source != StepSource.MANUAL) {
+            return existing.id
+        }
+        val entry = StepCountEntry(
+            id = existing?.id ?: 0,
+            dateEpochDay = dateEpochDay,
+            steps = steps,
+            source = source,
+            notes = notes,
+            timestamp = timestamp
+        )
+        return stepCountDao.upsert(entry)
+    }
+
+    suspend fun upsertStepCount(entry: StepCountEntry): Long = stepCountDao.upsert(entry)
 
     suspend fun hasSetBeenLoggedToday(setId: Long): Boolean {
         val calendar = java.util.Calendar.getInstance()

--- a/app/src/main/java/com/privatehealthjournal/sensor/HealthConnectStepReader.kt
+++ b/app/src/main/java/com/privatehealthjournal/sensor/HealthConnectStepReader.kt
@@ -1,0 +1,86 @@
+package com.privatehealthjournal.sensor
+
+import android.content.Context
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import com.privatehealthjournal.data.entity.StepSource
+import com.privatehealthjournal.data.preferences.AppPreferences
+import com.privatehealthjournal.data.preferences.StepPrefs
+import com.privatehealthjournal.data.repository.LogRepository
+import kotlinx.coroutines.flow.first
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class HealthConnectStepReader(
+    private val context: Context,
+    private val repository: LogRepository
+) {
+    suspend fun sync() {
+        if (!AppPreferences.getShowStepCounting(context).first()) return
+        if (!AppPreferences.getHealthConnectEnabled(context).first()) return
+
+        val sdkStatus = HealthConnectClient.getSdkStatus(context)
+        if (sdkStatus != HealthConnectClient.SDK_AVAILABLE) {
+            Log.d(TAG, "Health Connect SDK not available: $sdkStatus")
+            return
+        }
+
+        val client = try {
+            HealthConnectClient.getOrCreate(context)
+        } catch (e: Exception) {
+            Log.w(TAG, "HealthConnectClient.getOrCreate failed", e)
+            return
+        }
+
+        val readPerm = HealthPermission.getReadPermission(StepsRecord::class)
+        val granted = try {
+            client.permissionController.getGrantedPermissions()
+        } catch (e: Exception) {
+            Log.w(TAG, "getGrantedPermissions failed", e)
+            return
+        }
+        if (readPerm !in granted) return
+
+        val zone = ZoneId.systemDefault()
+        val today = LocalDate.now()
+        val startDay = today.minusDays(7)
+        val startInstant = startDay.atStartOfDay(zone).toInstant()
+        val endInstant = Instant.now()
+
+        val records = try {
+            client.readRecords(
+                ReadRecordsRequest(
+                    recordType = StepsRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(startInstant, endInstant)
+                )
+            ).records
+        } catch (e: Exception) {
+            Log.w(TAG, "readRecords failed", e)
+            return
+        }
+
+        val byDay = mutableMapOf<Long, Long>()
+        records.forEach { record ->
+            val day = record.startTime.atZone(zone).toLocalDate().toEpochDay()
+            byDay[day] = (byDay[day] ?: 0L) + record.count
+        }
+
+        byDay.forEach { (epochDay, totalSteps) ->
+            repository.recordStepCount(epochDay, totalSteps.toInt(), StepSource.HEALTH_CONNECT)
+        }
+        StepPrefs.setHcLastSyncEpochDay(context, today.toEpochDay())
+    }
+
+    companion object {
+        private const val TAG = "HCStepReader"
+
+        val REQUIRED_PERMISSIONS = setOf(
+            HealthPermission.getReadPermission(StepsRecord::class)
+        )
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/sensor/StepSensorReader.kt
+++ b/app/src/main/java/com/privatehealthjournal/sensor/StepSensorReader.kt
@@ -1,0 +1,88 @@
+package com.privatehealthjournal.sensor
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import com.privatehealthjournal.data.entity.StepSource
+import com.privatehealthjournal.data.preferences.AppPreferences
+import com.privatehealthjournal.data.preferences.StepPrefs
+import com.privatehealthjournal.data.repository.LogRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import java.time.LocalDate
+import kotlin.coroutines.resume
+
+class StepSensorReader(
+    private val context: Context,
+    private val repository: LogRepository
+) {
+    suspend fun sync() {
+        if (!AppPreferences.getShowStepCounting(context).first()) return
+        if (!AppPreferences.getStepSensorEnabled(context).first()) return
+        if (context.checkSelfPermission(android.Manifest.permission.ACTIVITY_RECOGNITION)
+            != PackageManager.PERMISSION_GRANTED
+        ) return
+
+        val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager ?: return
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER) ?: return
+
+        val current = readOnce(sensorManager, sensor) ?: return
+        val today = LocalDate.now().toEpochDay()
+        val lastCumulative = StepPrefs.getLastCumulative(context)
+        val lastEpochDay = StepPrefs.getLastReadingEpochDay(context)
+
+        if (lastCumulative == null) {
+            StepPrefs.setLastReading(context, current, today)
+            return
+        }
+
+        val delta = if (current < lastCumulative) {
+            current.toInt()
+        } else {
+            (current - lastCumulative).toInt()
+        }
+
+        if (delta > 0) {
+            val existingToday = repository.getStepCountByEpochDay(today)
+            val newTotal = if (lastEpochDay == today && existingToday != null && existingToday.source == StepSource.SENSOR) {
+                existingToday.steps + delta
+            } else {
+                delta + (existingToday?.steps?.takeIf { existingToday.source == StepSource.SENSOR } ?: 0)
+            }
+            repository.recordStepCount(today, newTotal, StepSource.SENSOR)
+        }
+        StepPrefs.setLastReading(context, current, today)
+    }
+
+    private suspend fun readOnce(sensorManager: SensorManager, sensor: Sensor): Long? =
+        withTimeoutOrNull(3000L) {
+            suspendCancellableCoroutine<Long?> { cont ->
+                val listener = object : SensorEventListener {
+                    override fun onSensorChanged(event: SensorEvent) {
+                        val value = event.values.firstOrNull()?.toLong()
+                        sensorManager.unregisterListener(this)
+                        if (cont.isActive) cont.resume(value)
+                    }
+                    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+                }
+                val registered = sensorManager.registerListener(
+                    listener, sensor, SensorManager.SENSOR_DELAY_NORMAL
+                )
+                if (!registered) {
+                    if (cont.isActive) cont.resume(null)
+                }
+                cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
+            }
+        }.also {
+            if (it == null) Log.d(TAG, "step sensor read timed out / failed")
+        }
+
+    companion object {
+        private const val TAG = "StepSensorReader"
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/sensor/StepSync.kt
+++ b/app/src/main/java/com/privatehealthjournal/sensor/StepSync.kt
@@ -1,0 +1,34 @@
+package com.privatehealthjournal.sensor
+
+import android.content.Context
+import android.util.Log
+import com.privatehealthjournal.data.repository.LogRepository
+
+class StepSync(
+    private val sensorReader: StepSensorReader,
+    private val hcReader: HealthConnectStepReader
+) {
+    suspend fun syncOnResume() {
+        try {
+            hcReader.sync()
+        } catch (e: Exception) {
+            Log.w(TAG, "HC sync failed", e)
+        }
+        try {
+            sensorReader.sync()
+        } catch (e: Exception) {
+            Log.w(TAG, "sensor sync failed", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "StepSync"
+
+        fun create(context: Context, repository: LogRepository): StepSync {
+            return StepSync(
+                StepSensorReader(context.applicationContext, repository),
+                HealthConnectStepReader(context.applicationContext, repository)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/components/BiometricsCharts.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/BiometricsCharts.kt
@@ -30,6 +30,7 @@ import com.privatehealthjournal.data.entity.CholesterolEntry
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.GlucoseUnit
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.data.entity.WeightUnit
 import com.patrykandpatrick.vico.compose.axis.horizontal.rememberBottomAxis
@@ -648,6 +649,102 @@ fun CholesterolSummaryCard(entries: List<CholesterolEntry>) {
             SummaryItem("Latest", latest?.total?.toString() ?: "-"),
             SummaryItem("Min", min?.total?.toString() ?: "-"),
             SummaryItem("Max", max?.total?.toString() ?: "-"),
+            SummaryItem("Avg", "%.0f".format(avg))
+        )
+    )
+}
+
+@Composable
+fun StepCountChart(
+    entries: List<StepCountEntry>,
+    modifier: Modifier = Modifier
+) {
+    if (entries.isEmpty()) {
+        EmptyChartState("No step data to display")
+        return
+    }
+
+    val sortedEntries = remember(entries) { entries.sortedBy { it.dateEpochDay } }
+    val chartColor = MaterialTheme.colorScheme.primary
+    val msPerDay = 24 * 60 * 60 * 1000L
+
+    val minDay = remember(sortedEntries) { sortedEntries.minOf { it.dateEpochDay } }
+
+    val chartEntryModelProducer = remember(sortedEntries) {
+        ChartEntryModelProducer(
+            sortedEntries.map { entry ->
+                val dayOffset = (entry.dateEpochDay - minDay).toFloat()
+                entryOf(dayOffset, entry.steps.toFloat())
+            }
+        )
+    }
+
+    val lineSpec = remember(chartColor) {
+        listOf(
+            LineChart.LineSpec(
+                lineColor = chartColor.toArgb(),
+                lineBackgroundShader = DynamicShaders.fromBrush(
+                    androidx.compose.ui.graphics.Brush.verticalGradient(
+                        listOf(
+                            chartColor.copy(alpha = 0.4f),
+                            chartColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    val bottomAxisFormatter = remember(minDay) {
+        AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+            val epochDay = minDay + value.toLong()
+            formatDateForAxis(epochDay * msPerDay)
+        }
+    }
+
+    val startAxisFormatter = remember {
+        AxisValueFormatter<AxisPosition.Vertical.Start> { value, _ ->
+            "%.0f".format(value)
+        }
+    }
+
+    val axisLabelComponent = textComponent(
+        color = MaterialTheme.colorScheme.onSurface,
+        textSize = 9.sp,
+        typeface = Typeface.DEFAULT
+    )
+
+    Chart(
+        chart = lineChart(lines = lineSpec),
+        chartModelProducer = chartEntryModelProducer,
+        startAxis = rememberStartAxis(valueFormatter = startAxisFormatter),
+        bottomAxis = rememberBottomAxis(
+            label = axisLabelComponent,
+            valueFormatter = bottomAxisFormatter,
+            tickLength = 4.dp,
+            itemPlacer = AxisItemPlacer.Horizontal.default(spacing = 3)
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(200.dp)
+    )
+}
+
+@Composable
+fun StepCountSummaryCard(entries: List<StepCountEntry>) {
+    if (entries.isEmpty()) return
+
+    val latest = entries.maxByOrNull { it.dateEpochDay }
+    val min = entries.minByOrNull { it.steps }
+    val max = entries.maxByOrNull { it.steps }
+    val avg = entries.map { it.steps }.average()
+
+    SummaryCard(
+        title = "Step Summary",
+        items = listOf(
+            SummaryItem("Latest", latest?.let { "${it.steps}" } ?: "-"),
+            SummaryItem("Min", min?.let { "${it.steps}" } ?: "-"),
+            SummaryItem("Max", max?.let { "${it.steps}" } ?: "-"),
             SummaryItem("Avg", "%.0f".format(avg))
         )
     )

--- a/app/src/main/java/com/privatehealthjournal/ui/components/StepCountCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/StepCountCard.kt
@@ -1,0 +1,155 @@
+package com.privatehealthjournal.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.StepCountEntry
+import com.privatehealthjournal.data.entity.StepSource
+import java.text.NumberFormat
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun StepCountCard(
+    entry: StepCountEntry,
+    onDelete: () -> Unit,
+    onEdit: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirm) {
+        DeleteConfirmationDialog(
+            onConfirm = { onDelete(); showDeleteConfirm = false },
+            onDismiss = { showDeleteConfirm = false }
+        )
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.DirectionsWalk,
+                contentDescription = "Steps",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Steps",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    SourceBadge(entry.source)
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = NumberFormat.getIntegerInstance(Locale.getDefault()).format(entry.steps),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                if (entry.notes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatDay(entry.dateEpochDay),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+            Column {
+                if (onEdit != null) {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+                IconButton(onClick = { showDeleteConfirm = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceBadge(source: StepSource) {
+    val label = when (source) {
+        StepSource.SENSOR -> "Sensor"
+        StepSource.HEALTH_CONNECT -> "Health Connect"
+        StepSource.MANUAL -> "Manual"
+    }
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = MaterialTheme.colorScheme.primaryContainer
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+        )
+    }
+}
+
+private fun formatDay(epochDay: Long): String {
+    val date = LocalDate.ofEpochDay(epochDay)
+    val millis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    val sdf = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+    return sdf.format(Date(millis))
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
@@ -1,0 +1,229 @@
+package com.privatehealthjournal.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.data.entity.StepCountEntry
+import com.privatehealthjournal.data.entity.StepSource
+import com.privatehealthjournal.ui.components.DatePickerDialogWrapper
+import com.privatehealthjournal.ui.components.formatDate
+import com.privatehealthjournal.viewmodel.LogViewModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddStepCountScreen(
+    viewModel: LogViewModel,
+    onNavigateBack: () -> Unit,
+    editId: Long? = null
+) {
+    val editingEntry by viewModel.editingStepCount.collectAsState()
+    val isEditMode = editId != null
+
+    var steps by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var dateMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingEntry by remember { mutableStateOf<StepCountEntry?>(null) }
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    LaunchedEffect(editId) {
+        if (editId != null) viewModel.loadStepCountForEditing(editId)
+    }
+
+    LaunchedEffect(editingEntry) {
+        editingEntry?.let { entry ->
+            steps = entry.steps.toString()
+            notes = entry.notes
+            val date = LocalDate.ofEpochDay(entry.dateEpochDay)
+            dateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            existingEntry = entry
+        }
+    }
+
+    val stepsValue = steps.toIntOrNull()
+    val isValid = stepsValue != null && stepsValue >= 0
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        if (isEditMode) "Edit Steps" else "Log Steps",
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.clearEditingState()
+                        onNavigateBack()
+                    }) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Icon(
+                imageVector = Icons.Default.DirectionsWalk,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Daily Step Count",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = steps,
+                onValueChange = { steps = it.filter { c -> c.isDigit() }.take(7) },
+                label = { Text("Steps") },
+                placeholder = { Text("8000") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Date",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showDatePicker = true },
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.CalendarMonth,
+                        contentDescription = "Select date",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = formatDate(dateMillis),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes (optional)") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                maxLines = 3
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    val stepsVal = steps.toIntOrNull() ?: return@Button
+                    val epochDay = Instant.ofEpochMilli(dateMillis)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate()
+                        .toEpochDay()
+
+                    val existing = existingEntry
+                    if (isEditMode && existing != null) {
+                        viewModel.updateStepCount(
+                            existing.copy(
+                                dateEpochDay = epochDay,
+                                steps = stepsVal,
+                                source = StepSource.MANUAL,
+                                notes = notes.trim()
+                            )
+                        )
+                    } else {
+                        viewModel.addStepCount(epochDay, stepsVal, notes.trim())
+                    }
+                    viewModel.clearEditingState()
+                    onNavigateBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = isValid
+            ) {
+                Text(if (isEditMode) "Update Steps" else "Save Steps")
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        DatePickerDialogWrapper(
+            initialTimestamp = dateMillis,
+            onDismiss = { showDatePicker = false },
+            onConfirm = { selectedDate ->
+                dateMillis = selectedDate
+                showDatePicker = false
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/BiometricsChartScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/BiometricsChartScreen.kt
@@ -42,6 +42,8 @@ import com.privatehealthjournal.ui.components.BloodGlucoseChart
 import com.privatehealthjournal.ui.components.BloodGlucoseSummaryCard
 import com.privatehealthjournal.ui.components.SpO2Chart
 import com.privatehealthjournal.ui.components.SpO2SummaryCard
+import com.privatehealthjournal.ui.components.StepCountChart
+import com.privatehealthjournal.ui.components.StepCountSummaryCard
 import com.privatehealthjournal.ui.components.WeightChart
 import com.privatehealthjournal.ui.components.WeightSummaryCard
 import com.privatehealthjournal.ui.utils.TimeRange
@@ -53,7 +55,8 @@ enum class BiometricTab(val title: String) {
     BLOOD_PRESSURE("Blood Pressure"),
     CHOLESTEROL("Cholesterol"),
     SPO2("SpO2"),
-    BLOOD_GLUCOSE("Blood Glucose")
+    BLOOD_GLUCOSE("Blood Glucose"),
+    STEPS("Steps")
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -70,6 +73,8 @@ fun BiometricsChartScreen(
     val allCholesterolEntries by viewModel.allCholesterolEntries.collectAsState()
     val allSpO2Entries by viewModel.allSpO2Entries.collectAsState()
     val allBloodGlucoseEntries by viewModel.allBloodGlucoseEntries.collectAsState()
+    val allStepCountEntries by viewModel.allStepCountEntries.collectAsState()
+    val showStepCounting by viewModel.showStepCounting.collectAsState()
 
     val filteredWeightEntries = remember(allWeightEntries, selectedTimeRange) {
         filterByTimeRange(allWeightEntries, selectedTimeRange) { it.timestamp }
@@ -89,6 +94,15 @@ fun BiometricsChartScreen(
 
     val filteredBloodGlucoseEntries = remember(allBloodGlucoseEntries, selectedTimeRange) {
         filterByTimeRange(allBloodGlucoseEntries, selectedTimeRange) { it.timestamp }
+    }
+
+    val filteredStepCountEntries = remember(allStepCountEntries, selectedTimeRange) {
+        filterByTimeRange(allStepCountEntries, selectedTimeRange) { it.timestamp }
+    }
+
+    val visibleTabs = remember(showStepCounting) {
+        if (showStepCounting) BiometricTab.entries
+        else BiometricTab.entries.filter { it != BiometricTab.STEPS }
     }
 
     Scaffold(
@@ -124,7 +138,7 @@ fun BiometricsChartScreen(
                 selectedTabIndex = selectedTab,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                BiometricTab.entries.forEachIndexed { index, tab ->
+                visibleTabs.forEachIndexed { index, tab ->
                     Tab(
                         selected = selectedTab == index,
                         onClick = { selectedTab = index },
@@ -156,7 +170,8 @@ fun BiometricsChartScreen(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // Chart Content
-                when (BiometricTab.entries[selectedTab]) {
+                val activeTab = visibleTabs.getOrElse(selectedTab) { visibleTabs.first() }
+                when (activeTab) {
                     BiometricTab.WEIGHT -> {
                         WeightChart(entries = filteredWeightEntries)
                         Spacer(modifier = Modifier.height(16.dp))
@@ -181,6 +196,11 @@ fun BiometricsChartScreen(
                         BloodGlucoseChart(entries = filteredBloodGlucoseEntries)
                         Spacer(modifier = Modifier.height(16.dp))
                         BloodGlucoseSummaryCard(entries = filteredBloodGlucoseEntries)
+                    }
+                    BiometricTab.STEPS -> {
+                        StepCountChart(entries = filteredStepCountEntries)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        StepCountSummaryCard(entries = filteredStepCountEntries)
                     }
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
@@ -49,6 +49,7 @@ import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
@@ -59,6 +60,7 @@ import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
 import com.privatehealthjournal.ui.components.SpO2Card
+import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
 import com.privatehealthjournal.viewmodel.LogViewModel
@@ -84,7 +86,8 @@ fun CalendarScreen(
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
     onEditBloodGlucose: (Long) -> Unit = {},
-    onEditCycleEntry: (Long) -> Unit = {}
+    onEditCycleEntry: (Long) -> Unit = {},
+    onEditStepCount: (Long) -> Unit = {}
 ) {
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
@@ -97,6 +100,8 @@ fun CalendarScreen(
     val allBloodGlucose by viewModel.allBloodGlucoseEntries.collectAsState()
     val allCycleEntries by viewModel.allCycleEntries.collectAsState()
     val showCycleTracking by viewModel.showCycleTracking.collectAsState()
+    val allStepCountEntries by viewModel.allStepCountEntries.collectAsState()
+    val showStepCounting by viewModel.showStepCounting.collectAsState()
 
     var currentMonth by remember { mutableStateOf(YearMonth.now()) }
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
@@ -104,7 +109,7 @@ fun CalendarScreen(
     val zone = ZoneId.systemDefault()
 
     // Group entries by date
-    val entriesByDate = remember(allMeals, allSymptoms, allMedications, allOtherEntries, allBloodPressure, allCholesterol, allWeight, allSpO2, allBloodGlucose, allCycleEntries, showCycleTracking) {
+    val entriesByDate = remember(allMeals, allSymptoms, allMedications, allOtherEntries, allBloodPressure, allCholesterol, allWeight, allSpO2, allBloodGlucose, allCycleEntries, showCycleTracking, allStepCountEntries, showStepCounting) {
         val map = mutableMapOf<LocalDate, MutableList<CalendarEntry>>()
 
         allMeals.forEach { meal ->
@@ -149,6 +154,12 @@ fun CalendarScreen(
                 map.getOrPut(date) { mutableListOf() }.add(CalendarEntry.Cycle(cycle))
             }
         }
+        if (showStepCounting) {
+            allStepCountEntries.forEach { step ->
+                val date = LocalDate.ofEpochDay(step.dateEpochDay)
+                map.getOrPut(date) { mutableListOf() }.add(CalendarEntry.StepCount(step))
+            }
+        }
 
         map
     }
@@ -171,6 +182,7 @@ fun CalendarScreen(
                 is CalendarEntry.SpO2 -> it.entry.timestamp
                 is CalendarEntry.BloodGlucose -> it.entry.timestamp
                 is CalendarEntry.Cycle -> it.entry.timestamp
+                is CalendarEntry.StepCount -> it.entry.timestamp
             }
         }
         ?: emptyList()
@@ -304,6 +316,11 @@ fun CalendarScreen(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteCycleEntry(entry.entry) },
                                 onEdit = { onEditCycleEntry(entry.entry.id) }
+                            )
+                            is CalendarEntry.StepCount -> StepCountCard(
+                                entry = entry.entry,
+                                onDelete = { viewModel.deleteStepCount(entry.entry) },
+                                onEdit = { onEditStepCount(entry.entry.id) }
                             )
                         }
                     }
@@ -484,4 +501,5 @@ private sealed class CalendarEntry {
     data class SpO2(val entry: SpO2Entry) : CalendarEntry()
     data class BloodGlucose(val entry: BloodGlucoseEntry) : CalendarEntry()
     data class Cycle(val entry: CycleEntry) : CalendarEntry()
+    data class StepCount(val entry: StepCountEntry) : CalendarEntry()
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
@@ -40,6 +40,7 @@ import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
@@ -50,6 +51,7 @@ import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
 import com.privatehealthjournal.ui.components.SpO2Card
+import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
 import com.privatehealthjournal.viewmodel.LogViewModel
@@ -76,7 +78,8 @@ fun HistoryScreen(
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
     onEditBloodGlucose: (Long) -> Unit = {},
-    onEditCycleEntry: (Long) -> Unit = {}
+    onEditCycleEntry: (Long) -> Unit = {},
+    onEditStepCount: (Long) -> Unit = {}
 ) {
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
@@ -89,6 +92,8 @@ fun HistoryScreen(
     val allBloodGlucose by viewModel.allBloodGlucoseEntries.collectAsState()
     val allCycleEntries by viewModel.allCycleEntries.collectAsState()
     val showCycleTracking by viewModel.showCycleTracking.collectAsState()
+    val allStepCountEntries by viewModel.allStepCountEntries.collectAsState()
+    val showStepCounting by viewModel.showStepCounting.collectAsState()
     var filterType by remember { mutableStateOf(FilterType.ALL) }
 
     Scaffold(
@@ -176,7 +181,8 @@ fun HistoryScreen(
                             allWeight.map { HistoryEntry.Weight(it) } +
                             allSpO2.map { HistoryEntry.SpO2(it) } +
                             allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
-                            (if (showCycleTracking) allCycleEntries.map { HistoryEntry.Cycle(it) } else emptyList()))
+                            (if (showCycleTracking) allCycleEntries.map { HistoryEntry.Cycle(it) } else emptyList()) +
+                            (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
                         .sortedByDescending { it.timestamp }
                 }
                 FilterType.MEALS -> allMeals.map { HistoryEntry.Meal(it) }
@@ -192,7 +198,8 @@ fun HistoryScreen(
                             allCholesterol.map { HistoryEntry.Cholesterol(it) } +
                             allWeight.map { HistoryEntry.Weight(it) } +
                             allSpO2.map { HistoryEntry.SpO2(it) } +
-                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) })
+                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
+                            (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
                         .sortedByDescending { it.timestamp }
                 }
                 FilterType.CYCLE -> allCycleEntries.map { HistoryEntry.Cycle(it) }
@@ -311,6 +318,11 @@ fun HistoryScreen(
                                     onDelete = { viewModel.deleteCycleEntry(entry.entry) },
                                     onEdit = { onEditCycleEntry(entry.entry.id) }
                                 )
+                                is HistoryEntry.StepCount -> StepCountCard(
+                                    entry = entry.entry,
+                                    onDelete = { viewModel.deleteStepCount(entry.entry) },
+                                    onEdit = { onEditStepCount(entry.entry.id) }
+                                )
                             }
                         }
                     }
@@ -361,5 +373,13 @@ private sealed class HistoryEntry {
 
     data class Cycle(val entry: CycleEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+    }
+
+    data class StepCount(val entry: StepCountEntry) : HistoryEntry() {
+        override val timestamp: Long =
+            LocalDate.ofEpochDay(entry.dateEpochDay)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Medication
@@ -61,6 +62,7 @@ import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.ui.components.BloodGlucoseCard
@@ -71,6 +73,7 @@ import com.privatehealthjournal.ui.components.MealEntryCard
 import com.privatehealthjournal.ui.components.MedicationCard
 import com.privatehealthjournal.ui.components.OtherEntryCard
 import com.privatehealthjournal.ui.components.SpO2Card
+import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
 import com.privatehealthjournal.viewmodel.LogViewModel
@@ -92,6 +95,7 @@ fun HomeScreen(
     onAddWeight: () -> Unit,
     onAddSpO2: () -> Unit,
     onAddBloodGlucose: () -> Unit,
+    onAddStepCount: () -> Unit = {},
     onViewBiometricsChart: () -> Unit = {},
     onViewHistory: () -> Unit,
     onViewCalendar: () -> Unit = {},
@@ -105,6 +109,7 @@ fun HomeScreen(
     onEditWeight: (Long) -> Unit = {},
     onEditSpO2: (Long) -> Unit = {},
     onEditBloodGlucose: (Long) -> Unit = {},
+    onEditStepCount: (Long) -> Unit = {},
     onViewMedicationSets: () -> Unit = {},
     onViewMealBudget: () -> Unit = {},
     onViewCycleTracking: () -> Unit = {},
@@ -121,6 +126,8 @@ fun HomeScreen(
     val recentBloodGlucose by viewModel.recentBloodGlucoseEntries.collectAsState()
     val recentCycleEntries by viewModel.recentCycleEntries.collectAsState()
     val showCycleTracking by viewModel.showCycleTracking.collectAsState()
+    val recentStepCount by viewModel.recentStepCountEntries.collectAsState()
+    val showStepCounting by viewModel.showStepCounting.collectAsState()
 
     var medsMenuExpanded by remember { mutableStateOf(false) }
     var biometricsMenuExpanded by remember { mutableStateOf(false) }
@@ -313,6 +320,15 @@ fun HomeScreen(
                                 onAddBloodGlucose()
                             }
                         )
+                        if (showStepCounting) {
+                            DropdownMenuItem(
+                                text = { Text("Steps") },
+                                onClick = {
+                                    biometricsMenuExpanded = false
+                                    onAddStepCount()
+                                }
+                            )
+                        }
                         Divider()
                         DropdownMenuItem(
                             text = { Text("View Charts") },
@@ -441,7 +457,8 @@ fun HomeScreen(
                 recentBloodPressure.isEmpty() && recentCholesterol.isEmpty() &&
                 recentWeight.isEmpty() && recentSpO2.isEmpty() &&
                 recentBloodGlucose.isEmpty() &&
-                (!showCycleTracking || recentCycleEntries.isEmpty())
+                (!showCycleTracking || recentCycleEntries.isEmpty()) &&
+                (!showStepCounting || recentStepCount.isEmpty())
 
             if (allEmpty) {
                 Column(
@@ -478,7 +495,8 @@ fun HomeScreen(
                     recentWeight.map { EntryItem.Weight(it) } +
                     recentSpO2.map { EntryItem.SpO2(it) } +
                     recentBloodGlucose.map { EntryItem.BloodGlucose(it) } +
-                    (if (showCycleTracking) recentCycleEntries.map { EntryItem.Cycle(it) } else emptyList())
+                    (if (showCycleTracking) recentCycleEntries.map { EntryItem.Cycle(it) } else emptyList()) +
+                    (if (showStepCounting) recentStepCount.map { EntryItem.StepCount(it) } else emptyList())
                 )
                     .sortedByDescending { it.timestamp }
                     .take(10)
@@ -580,6 +598,11 @@ fun HomeScreen(
                                     onDelete = { viewModel.deleteCycleEntry(item.entry) },
                                     onEdit = { onEditCycleEntry(item.entry.id) }
                                 )
+                                is EntryItem.StepCount -> StepCountCard(
+                                    entry = item.entry,
+                                    onDelete = { viewModel.deleteStepCount(item.entry) },
+                                    onEdit = { onEditStepCount(item.entry.id) }
+                                )
                             }
                         }
                     }
@@ -621,5 +644,12 @@ private sealed class EntryItem {
     }
     data class Cycle(val entry: CycleEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+    }
+    data class StepCount(val entry: StepCountEntry) : EntryItem() {
+        override val timestamp: Long =
+            LocalDate.ofEpochDay(entry.dateEpochDay)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
@@ -51,6 +51,7 @@ import com.privatehealthjournal.data.entity.MealType
 import com.privatehealthjournal.data.entity.MealWithDetails
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.OtherEntryType
+import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.time.DayOfWeek
 import java.time.Instant
@@ -68,8 +69,17 @@ fun MealBudgetScreen(
 ) {
     val allMeals by viewModel.allMeals.collectAsState()
     val allOtherEntries by viewModel.allOtherEntries.collectAsState()
+    val allStepCountEntries by viewModel.allStepCountEntries.collectAsState()
+    val stepsPerPointCredit by viewModel.stepsPerPointCredit.collectAsState()
     val dailyBudgetState by viewModel.dailyBudget.collectAsState()
     val dailyBudget = dailyBudgetState
+
+    fun stepCreditsForDay(day: LocalDate): Int {
+        val divisor = stepsPerPointCredit ?: return 0
+        if (divisor <= 0) return 0
+        val entry = allStepCountEntries.firstOrNull { it.dateEpochDay == day.toEpochDay() } ?: return 0
+        return entry.steps / divisor
+    }
 
     var weekOffset by remember { mutableIntStateOf(0) }
     var selectedDay by remember { mutableStateOf<LocalDate?>(null) }
@@ -91,7 +101,8 @@ fun MealBudgetScreen(
 
     val weeklyMealPoints = weekMeals.sumOf { it.meal.pointCost ?: 0 }
     val weeklyExerciseCredits = weekExercise.sumOf { it.pointCredit ?: 0 }
-    val netWeeklyPoints = weeklyMealPoints - weeklyExerciseCredits
+    val weeklyStepCredits = (0..6).sumOf { stepCreditsForDay(weekStart.plusDays(it.toLong())) }
+    val netWeeklyPoints = weeklyMealPoints - weeklyExerciseCredits - weeklyStepCredits
 
     val weeklyBudget = (dailyBudget ?: 0) * 8
     val weeklyRemaining = weeklyBudget - netWeeklyPoints
@@ -108,7 +119,8 @@ fun MealBudgetScreen(
         val dayExercisePts = allOtherEntries
             .filter { it.entryType == OtherEntryType.EXERCISE && it.timestamp in dayStartMs until dayEndMs }
             .sumOf { it.pointCredit ?: 0 }
-        maxOf(0, dayMealPts - dayExercisePts - (dailyBudget ?: 0))
+        val dayStepPts = stepCreditsForDay(day)
+        maxOf(0, dayMealPts - dayExercisePts - dayStepPts - (dailyBudget ?: 0))
     }
 
     val headerFormatter = DateTimeFormatter.ofPattern("MMM d")
@@ -192,6 +204,7 @@ fun MealBudgetScreen(
                 netWeeklyPoints = netWeeklyPoints,
                 weeklyMealPoints = weeklyMealPoints,
                 weeklyExerciseCredits = weeklyExerciseCredits,
+                weeklyStepCredits = weeklyStepCredits,
                 weeklyRemaining = weeklyRemaining,
                 overageUsed = overageUsed
             )
@@ -218,7 +231,9 @@ fun MealBudgetScreen(
                 }
                 val dayMealPoints = dayMeals.sumOf { it.meal.pointCost ?: 0 }
                 val dayExerciseCredits = dayExercise.sumOf { it.pointCredit ?: 0 }
-                val dayNet = dayMealPoints - dayExerciseCredits
+                val dayStepEntry = allStepCountEntries.firstOrNull { it.dateEpochDay == day.toEpochDay() }
+                val dayStepCredits = stepCreditsForDay(day)
+                val dayNet = dayMealPoints - dayExerciseCredits - dayStepCredits
                 val isExpanded = selectedDay == day
 
                 DayRow(
@@ -230,6 +245,8 @@ fun MealBudgetScreen(
                     isExpanded = isExpanded,
                     dayMeals = dayMeals,
                     dayExercise = dayExercise,
+                    dayStepEntry = dayStepEntry,
+                    dayStepCredits = dayStepCredits,
                     dayFormatter = dayFormatter,
                     onClick = {
                         selectedDay = if (isExpanded) null else day
@@ -283,6 +300,7 @@ private fun WeeklySummaryCard(
     netWeeklyPoints: Int,
     weeklyMealPoints: Int,
     weeklyExerciseCredits: Int,
+    weeklyStepCredits: Int,
     weeklyRemaining: Int,
     overageUsed: Int
 ) {
@@ -338,9 +356,14 @@ private fun WeeklySummaryCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
             )
-            if (weeklyExerciseCredits > 0) {
+            if (weeklyExerciseCredits > 0 || weeklyStepCredits > 0) {
+                val parts = buildList {
+                    add("Meal pts: $weeklyMealPoints")
+                    if (weeklyExerciseCredits > 0) add("Exercise credits: −$weeklyExerciseCredits")
+                    if (weeklyStepCredits > 0) add("Step credits: −$weeklyStepCredits")
+                }
                 Text(
-                    text = "Meal pts: $weeklyMealPoints  |  Exercise credits: −$weeklyExerciseCredits",
+                    text = parts.joinToString("  |  "),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                 )
@@ -370,12 +393,14 @@ private fun DayRow(
     isExpanded: Boolean,
     dayMeals: List<MealWithDetails>,
     dayExercise: List<OtherEntry>,
+    dayStepEntry: StepCountEntry?,
+    dayStepCredits: Int,
     dayFormatter: DateTimeFormatter,
     onClick: () -> Unit
 ) {
     val progress = if (dailyBudget > 0) (dayNet.toFloat() / dailyBudget).coerceIn(0f, 1f) else 0f
     val isOver = dayNet > dailyBudget
-    val hasItems = dayMeals.isNotEmpty() || dayExercise.isNotEmpty()
+    val hasItems = dayMeals.isNotEmpty() || dayExercise.isNotEmpty() || dayStepCredits > 0
     val barColor = when {
         isFuture -> Color.Transparent
         isOver -> MaterialTheme.colorScheme.error
@@ -498,6 +523,41 @@ private fun DayRow(
                                 fontWeight = FontWeight.Medium,
                                 color = if (meal.pointCost != null) MaterialTheme.colorScheme.onSurface
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+
+                    if (dayStepEntry != null && dayStepCredits > 0) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.DirectionsRun,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.tertiary
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Steps",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Text(
+                                    text = "${dayStepEntry.steps} steps",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                )
+                            }
+                            Text(
+                                text = "−$dayStepCredits pts",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Medium,
+                                color = Color(0xFF4CAF50)
                             )
                         }
                     }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
@@ -47,6 +47,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.PermissionController
+import com.privatehealthjournal.sensor.HealthConnectStepReader
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -65,11 +68,39 @@ fun SettingsScreen(
     val allOtherEntries by viewModel.allOtherEntries.collectAsState()
     val dailyBudget by viewModel.dailyBudget.collectAsState()
     val showCycleTracking by viewModel.showCycleTracking.collectAsState()
+    val showStepCounting by viewModel.showStepCounting.collectAsState()
+    val stepSensorEnabled by viewModel.stepSensorEnabled.collectAsState()
+    val healthConnectEnabled by viewModel.healthConnectEnabled.collectAsState()
+    val stepsPerPointCredit by viewModel.stepsPerPointCredit.collectAsState()
 
     var budgetText by remember { mutableStateOf("") }
+    var stepsPerCreditText by remember { mutableStateOf("") }
 
     LaunchedEffect(dailyBudget) {
         budgetText = dailyBudget?.toString() ?: ""
+    }
+
+    LaunchedEffect(stepsPerPointCredit) {
+        stepsPerCreditText = stepsPerPointCredit?.toString() ?: ""
+    }
+
+    val activityRecognitionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        viewModel.setStepSensorEnabled(granted)
+        if (!granted) {
+            Toast.makeText(context, "Activity recognition permission required", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val hcPermissionLauncher = rememberLauncherForActivityResult(
+        contract = PermissionController.createRequestPermissionResultContract()
+    ) { granted ->
+        val ok = granted.containsAll(HealthConnectStepReader.REQUIRED_PERMISSIONS)
+        viewModel.setHealthConnectEnabled(ok)
+        if (!ok) {
+            Toast.makeText(context, "Health Connect permission required", Toast.LENGTH_SHORT).show()
+        }
     }
 
     val totalEntries = allMeals.size + allSymptoms.size + allMedications.size + allOtherEntries.size
@@ -203,6 +234,162 @@ fun SettingsScreen(
                 enabled = budgetText.toIntOrNull() != null || (budgetText.isEmpty() && dailyBudget != null)
             ) {
                 Text(if (budgetText.isEmpty() && dailyBudget != null) "Clear Budget" else "Save Budget")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = stepsPerCreditText,
+                onValueChange = { newVal ->
+                    if (newVal.isEmpty() || newVal.all { it.isDigit() }) {
+                        stepsPerCreditText = newVal
+                    }
+                },
+                label = { Text("Steps per point credit") },
+                placeholder = { Text("e.g., 100") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = { viewModel.saveStepsPerPointCredit(stepsPerCreditText.toIntOrNull()) }
+                ),
+                supportingText = { Text("How many steps earn one credit. Leave blank to disable.") }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = { viewModel.saveStepsPerPointCredit(stepsPerCreditText.toIntOrNull()) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = stepsPerCreditText.toIntOrNull()?.let { it > 0 } == true ||
+                    (stepsPerCreditText.isEmpty() && stepsPerPointCredit != null)
+            ) {
+                Text(
+                    if (stepsPerCreditText.isEmpty() && stepsPerPointCredit != null)
+                        "Clear" else "Save"
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Step Counting",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Enable step counting",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Text(
+                                text = "Track daily step counts on Home, History, Calendar and charts.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = showStepCounting,
+                            onCheckedChange = { viewModel.setShowStepCounting(it) }
+                        )
+                    }
+
+                    if (showStepCounting) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Use device step sensor",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Text(
+                                    text = "Read built-in pedometer when app opens.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Switch(
+                                checked = stepSensorEnabled,
+                                onCheckedChange = { wantOn ->
+                                    if (wantOn) {
+                                        activityRecognitionLauncher.launch(
+                                            android.Manifest.permission.ACTIVITY_RECOGNITION
+                                        )
+                                    } else {
+                                        viewModel.setStepSensorEnabled(false)
+                                    }
+                                }
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Use Health Connect",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Text(
+                                    text = "Pull steps from Google Health Connect.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Switch(
+                                checked = healthConnectEnabled,
+                                onCheckedChange = { wantOn ->
+                                    if (wantOn) {
+                                        val status = HealthConnectClient.getSdkStatus(context)
+                                        if (status != HealthConnectClient.SDK_AVAILABLE) {
+                                            Toast.makeText(
+                                                context,
+                                                "Install Health Connect to enable.",
+                                                Toast.LENGTH_LONG
+                                            ).show()
+                                            viewModel.setHealthConnectEnabled(false)
+                                        } else {
+                                            hcPermissionLauncher.launch(
+                                                HealthConnectStepReader.REQUIRED_PERMISSIONS
+                                            )
+                                        }
+                                    } else {
+                                        viewModel.setHealthConnectEnabled(false)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
@@ -26,6 +26,8 @@ import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.GlucoseMealContext
 import com.privatehealthjournal.data.entity.GlucoseUnit
 import com.privatehealthjournal.data.entity.SpO2Entry
+import com.privatehealthjournal.data.entity.StepCountEntry
+import com.privatehealthjournal.data.entity.StepSource
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.data.entity.Tag
 import com.privatehealthjournal.data.entity.WeightEntry
@@ -83,6 +85,12 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     val allCycleEntries: StateFlow<List<CycleEntry>>
     val recentCycleEntries: StateFlow<List<CycleEntry>>
     val showCycleTracking: StateFlow<Boolean>
+    val allStepCountEntries: StateFlow<List<StepCountEntry>>
+    val recentStepCountEntries: StateFlow<List<StepCountEntry>>
+    val showStepCounting: StateFlow<Boolean>
+    val stepSensorEnabled: StateFlow<Boolean>
+    val healthConnectEnabled: StateFlow<Boolean>
+    val stepsPerPointCredit: StateFlow<Int?>
 
     init {
         val database = AppDatabase.getDatabase(application)
@@ -100,7 +108,8 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             database.medicationSetDao(),
             database.medicationSetReminderDao(),
             database.medicationSetLogDao(),
-            database.cycleEntryDao()
+            database.cycleEntryDao(),
+            database.stepCountDao()
         )
 
         allMeals = repository.allMeals
@@ -211,6 +220,24 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
 
         showCycleTracking = AppPreferences.getShowCycleTracking(application)
             .stateIn(viewModelScope, SharingStarted.Lazily, true)
+
+        allStepCountEntries = repository.allStepCountEntries
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        recentStepCountEntries = repository.getRecentStepCountEntries(5)
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+        showStepCounting = AppPreferences.getShowStepCounting(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+        stepSensorEnabled = AppPreferences.getStepSensorEnabled(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+        healthConnectEnabled = AppPreferences.getHealthConnectEnabled(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+        stepsPerPointCredit = BudgetPreferences.getStepsPerPointCredit(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, null)
     }
 
     fun addMeal(
@@ -578,6 +605,9 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     private val _editingCycleEntry = MutableStateFlow<CycleEntry?>(null)
     val editingCycleEntry: StateFlow<CycleEntry?> = _editingCycleEntry.asStateFlow()
 
+    private val _editingStepCount = MutableStateFlow<StepCountEntry?>(null)
+    val editingStepCount: StateFlow<StepCountEntry?> = _editingStepCount.asStateFlow()
+
     fun loadSymptomForEditing(id: Long) {
         viewModelScope.launch {
             _editingSymptom.value = repository.getSymptomById(id)
@@ -650,6 +680,49 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun loadStepCountForEditing(id: Long) {
+        viewModelScope.launch {
+            _editingStepCount.value = repository.getStepCountById(id)
+        }
+    }
+
+    // Step count methods
+    fun addStepCount(dateEpochDay: Long, steps: Int, notes: String = "") {
+        viewModelScope.launch {
+            repository.recordStepCount(dateEpochDay, steps, StepSource.MANUAL, notes)
+        }
+    }
+
+    fun updateStepCount(entry: StepCountEntry) {
+        viewModelScope.launch { repository.updateStepCount(entry) }
+    }
+
+    fun deleteStepCount(entry: StepCountEntry) {
+        viewModelScope.launch { repository.deleteStepCount(entry) }
+    }
+
+    fun setShowStepCounting(show: Boolean) {
+        viewModelScope.launch { AppPreferences.setShowStepCounting(getApplication(), show) }
+    }
+
+    fun setStepSensorEnabled(enabled: Boolean) {
+        viewModelScope.launch { AppPreferences.setStepSensorEnabled(getApplication(), enabled) }
+    }
+
+    fun setHealthConnectEnabled(enabled: Boolean) {
+        viewModelScope.launch { AppPreferences.setHealthConnectEnabled(getApplication(), enabled) }
+    }
+
+    fun saveStepsPerPointCredit(value: Int?) {
+        viewModelScope.launch {
+            if (value == null || value <= 0) {
+                BudgetPreferences.clearStepsPerPointCredit(getApplication())
+            } else {
+                BudgetPreferences.setStepsPerPointCredit(getApplication(), value)
+            }
+        }
+    }
+
     fun clearEditingState() {
         _editingSymptom.value = null
         _editingBowelMovement.value = null
@@ -663,6 +736,7 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         _editingBloodGlucose.value = null
         _editingMedicationSet.value = null
         _editingCycleEntry.value = null
+        _editingStepCount.value = null
     }
 
     // Medication Set methods
@@ -753,7 +827,8 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
                     medicationSets = allMedicationSets.value,
                     remindersBySetId = allRemindersBySet.value,
                     logsBySetId = logsBySetId,
-                    cycleEntries = allCycleEntries.value
+                    cycleEntries = allCycleEntries.value,
+                    stepCountEntries = allStepCountEntries.value
                 )
                 getApplication<Application>().contentResolver.openOutputStream(uri)?.use { stream ->
                     stream.write(json.toByteArray())

--- a/app/src/test/java/com/privatehealthjournal/data/export/DataExporterTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/data/export/DataExporterTest.kt
@@ -34,7 +34,7 @@ class DataExporterTest {
         )
 
         val result = gson.fromJson(json, ExportData::class.java)
-        assertThat(result.version).isEqualTo(5)
+        assertThat(result.version).isEqualTo(6)
         assertThat(result.exportedAt).isGreaterThan(0L)
     }
 

--- a/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/repository/LogRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.privatehealthjournal.data.dao.MedicationSetReminderDao
 import com.privatehealthjournal.data.dao.OtherEntryDao
 import com.privatehealthjournal.data.dao.BloodGlucoseDao
 import com.privatehealthjournal.data.dao.SpO2Dao
+import com.privatehealthjournal.data.dao.StepCountDao
 import com.privatehealthjournal.data.dao.SymptomEntryDao
 import com.privatehealthjournal.data.dao.CycleEntryDao
 import com.privatehealthjournal.data.dao.WeightDao
@@ -43,6 +44,7 @@ class LogRepositoryTest {
     private lateinit var medicationSetReminderDao: MedicationSetReminderDao
     private lateinit var medicationSetLogDao: MedicationSetLogDao
     private lateinit var cycleEntryDao: CycleEntryDao
+    private lateinit var stepCountDao: StepCountDao
     private lateinit var repository: LogRepository
 
     @Before
@@ -61,7 +63,9 @@ class LogRepositoryTest {
         medicationSetReminderDao = mockk(relaxed = true)
         medicationSetLogDao = mockk(relaxed = true)
         cycleEntryDao = mockk(relaxed = true)
+        stepCountDao = mockk(relaxed = true)
         every { cycleEntryDao.getAllCycleEntries() } returns flowOf(emptyList())
+        every { stepCountDao.getAllStepCountEntries() } returns flowOf(emptyList())
 
         every { mealDao.getAllMealsWithDetails() } returns flowOf(emptyList())
         every { mealDao.getAllTags() } returns flowOf(emptyList())
@@ -92,7 +96,8 @@ class LogRepositoryTest {
             medicationSetDao,
             medicationSetReminderDao,
             medicationSetLogDao,
-            cycleEntryDao
+            cycleEntryDao,
+            stepCountDao
         )
     }
 


### PR DESCRIPTION
Daily step counts as a new biometric. All automated tracking is opt-in via Settings: master "Enable step counting" toggle plus nested device sensor (TYPE_STEP_COUNTER) and Health Connect toggles, all default OFF. Manual entry available like any other biometric.

One row per calendar day enforced by unique index on dateEpochDay. Merge rule keeps MANUAL entries sticky; auto sources overwrite each other freely. Sensor reader computes deltas with reboot detection on app resume; Health Connect reader backfills 7 days.

MealBudgetScreen credits steps via configurable "Steps per point credit" pref (steps / N), computed live so changes apply retroactively without touching stored data.

DB 13 to 14 with explicit MIGRATION_13_14. Export bumped to v6 with stepCountEntries; importer upserts to bypass merge rule for trust-source restore.