### PR TITLE
fix: disable PHI cloud backup; correct step source merge

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     </queries>
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
@@ -385,7 +385,8 @@ class LogRepository(
     suspend fun getStepCountByEpochDay(day: Long): StepCountEntry? = stepCountDao.getByEpochDay(day)
 
     /**
-     * Merge rule: manual entries are sticky; auto sources overwrite each other freely.
+     * Merge rule: a higher-priority source never gets overwritten by a lower-priority one.
+     * Priority: MANUAL > HEALTH_CONNECT > SENSOR. A same-or-higher-priority write replaces.
      * Returns the row id (existing or new).
      */
     suspend fun recordStepCount(
@@ -396,7 +397,7 @@ class LogRepository(
         timestamp: Long = System.currentTimeMillis()
     ): Long {
         val existing = stepCountDao.getByEpochDay(dateEpochDay)
-        if (existing != null && existing.source == StepSource.MANUAL && source != StepSource.MANUAL) {
+        if (existing != null && stepSourcePriority(existing.source) > stepSourcePriority(source)) {
             return existing.id
         }
         val entry = StepCountEntry(
@@ -408,6 +409,12 @@ class LogRepository(
             timestamp = timestamp
         )
         return stepCountDao.upsert(entry)
+    }
+
+    private fun stepSourcePriority(source: StepSource): Int = when (source) {
+        StepSource.MANUAL -> 2
+        StepSource.HEALTH_CONNECT -> 1
+        StepSource.SENSOR -> 0
     }
 
     suspend fun upsertStepCount(entry: StepCountEntry): Long = stepCountDao.upsert(entry)

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.StepCountEntry
-import com.privatehealthjournal.data.entity.StepSource
 import com.privatehealthjournal.ui.components.DatePickerDialogWrapper
 import com.privatehealthjournal.ui.components.formatDate
 import com.privatehealthjournal.viewmodel.LogViewModel
@@ -198,7 +197,6 @@ fun AddStepCountScreen(
                             existing.copy(
                                 dateEpochDay = epochDay,
                                 steps = stepsVal,
-                                source = StepSource.MANUAL,
                                 notes = notes.trim()
                             )
                         )

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,3 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Health data is sensitive PHI. Excluded from Auto Backup (pre-API 31) as a
+    defense-in-depth measure on top of android:allowBackup="false". Users export
+    data manually via Settings → Export.
+-->
 <full-backup-content>
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="root" path="." />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Health data is sensitive PHI. Excluded from cloud backup and device-to-device
+    transfer (API 31+) as a defense-in-depth measure on top of
+    android:allowBackup="false". Users export data manually via Settings → Export.
+-->
 <data-extraction-rules>
     <cloud-backup>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="root" path="." />
     </cloud-backup>
     <device-transfer>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="root" path="." />
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
- AndroidManifest: allowBackup=false. Empty backup/data-extraction rules defaulted to including everything, exposing symptoms, medications, cycle, and biometrics to Auto Backup / Google Drive.
- backup_rules.xml + data_extraction_rules.xml: add explicit <exclude> blocks for database, sharedpref, file, root as defense-in-depth.
- LogRepository.recordStepCount: replace MANUAL-sticky rule with a priority ladder (MANUAL > HEALTH_CONNECT > SENSOR). Previously HEALTH_CONNECT and SENSOR could silently clobber each other when both were enabled.
- AddStepCountScreen: stop forcing source=MANUAL on edit so editing a sensor- or Health-Connect-sourced entry preserves its origin and keeps merge protection intact for future syncs.