### PR TITLE
fix: harden export, import, med-set logging, and reminders

### DIFF
--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.lifecycleScope
+import androidx.room.withTransaction
 import com.privatehealthjournal.data.AppDatabase
 import com.privatehealthjournal.data.repository.LogRepository
 import kotlinx.coroutines.launch
@@ -75,7 +76,8 @@ class MainActivity : ComponentActivity() {
             db.cholesterolDao(), db.weightDao(), db.spO2Dao(),
             db.bloodGlucoseDao(), db.medicationSetDao(),
             db.medicationSetReminderDao(), db.medicationSetLogDao(),
-            db.cycleEntryDao(), db.stepCountDao()
+            db.cycleEntryDao(), db.stepCountDao(),
+            transaction = { block -> db.withTransaction { block() } }
         )
         stepSync = StepSync.create(applicationContext, syncRepo)
 
@@ -473,6 +475,7 @@ class MainActivity : ComponentActivity() {
             NotificationManager.IMPORTANCE_HIGH
         ).apply {
             description = "Reminders to log medication sets"
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PRIVATE
         }
         val notificationManager = getSystemService(NotificationManager::class.java)
         notificationManager.createNotificationChannel(channel)

--- a/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/repository/LogRepository.kt
@@ -53,7 +53,8 @@ class LogRepository(
     private val medicationSetReminderDao: MedicationSetReminderDao,
     private val medicationSetLogDao: MedicationSetLogDao,
     private val cycleEntryDao: CycleEntryDao,
-    private val stepCountDao: StepCountDao
+    private val stepCountDao: StepCountDao,
+    private val transaction: suspend (suspend () -> Unit) -> Unit = { block -> block() }
 ) {
     val allMeals: Flow<List<MealWithDetails>> = mealDao.getAllMealsWithDetails()
     val allSymptomEntries: Flow<List<SymptomEntry>> = symptomEntryDao.getAllSymptomEntries()
@@ -369,6 +370,34 @@ class LogRepository(
 
     fun getAllMedicationSetLogs(): Flow<List<MedicationSetLog>> =
         medicationSetLogDao.getAllLogs()
+
+    /**
+     * Insert one MedicationEntry per item plus the set-log row atomically. Either everything
+     * commits or nothing does, so a crash mid-loop can't leave orphan MedicationEntries with
+     * no MedicationSetLog (which would let the reminder fire again the same day).
+     */
+    suspend fun logMedicationSetAtomically(
+        setId: Long,
+        items: List<MedicationSetItemSpec>,
+        timestamp: Long,
+        notes: String
+    ) {
+        transaction {
+            items.forEach { item ->
+                medicationDao.insert(
+                    MedicationEntry(
+                        name = item.name,
+                        dosage = item.dosage,
+                        notes = notes,
+                        timestamp = timestamp
+                    )
+                )
+            }
+            medicationSetLogDao.insert(MedicationSetLog(setId = setId, timestamp = timestamp))
+        }
+    }
+
+    data class MedicationSetItemSpec(val name: String, val dosage: String)
 
     // Cycle Entry methods
     suspend fun insertCycleEntry(entry: CycleEntry): Long = cycleEntryDao.insert(entry)

--- a/app/src/main/java/com/privatehealthjournal/notification/ReminderBroadcastReceiver.kt
+++ b/app/src/main/java/com/privatehealthjournal/notification/ReminderBroadcastReceiver.kt
@@ -83,11 +83,21 @@ class ReminderBroadcastReceiver : BroadcastReceiver() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        // Generic public version shown on a secure lockscreen so the medication set name
+        // (which can disclose a sensitive condition) is not visible to bystanders.
+        val publicNotification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Reminder")
+            .setContentText("Tap to open")
+            .build()
+
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle("Time to log: $setName")
             .setContentText("Tap to open medication sets and log your medications")
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+            .setPublicVersion(publicNotification)
             .setAutoCancel(true)
             .setContentIntent(pendingTapIntent)
             .build()

--- a/app/src/main/java/com/privatehealthjournal/notification/ReminderScheduler.kt
+++ b/app/src/main/java/com/privatehealthjournal/notification/ReminderScheduler.kt
@@ -64,9 +64,18 @@ object ReminderScheduler {
         notificationManager.cancel(setId.toInt())
     }
 
-    fun computeNextTriggerTime(reminder: MedicationSetReminder): Long {
-        val now = Calendar.getInstance()
+    fun computeNextTriggerTime(reminder: MedicationSetReminder): Long =
+        computeNextTriggerTime(reminder, System.currentTimeMillis())
+
+    /**
+     * Pure variant accepting the current time as a parameter so the day-wrap, all-days-off,
+     * and "today's slot already passed" branches can be exercised in unit tests without
+     * relying on the system clock. Visible for testing.
+     */
+    fun computeNextTriggerTime(reminder: MedicationSetReminder, nowMillis: Long): Long {
+        val now = Calendar.getInstance().apply { timeInMillis = nowMillis }
         val candidate = Calendar.getInstance().apply {
+            timeInMillis = nowMillis
             set(Calendar.HOUR_OF_DAY, reminder.hour)
             set(Calendar.MINUTE, reminder.minute)
             set(Calendar.SECOND, 0)
@@ -85,7 +94,7 @@ object ReminderScheduler {
                 }
             }
         }
-        // Fallback: schedule for tomorrow at the specified time
+        // Fallback (no days enabled): schedule for tomorrow at the specified time
         candidate.timeInMillis = now.timeInMillis
         candidate.add(Calendar.DAY_OF_YEAR, 1)
         candidate.set(Calendar.HOUR_OF_DAY, reminder.hour)

--- a/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/privatehealthjournal/viewmodel/LogViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.room.withTransaction
 import com.privatehealthjournal.data.AppDatabase
 import com.privatehealthjournal.data.export.DataExporter
 import com.privatehealthjournal.data.export.DataImporter
@@ -41,7 +42,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -109,7 +112,8 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
             database.medicationSetReminderDao(),
             database.medicationSetLogDao(),
             database.cycleEntryDao(),
-            database.stepCountDao()
+            database.stepCountDao(),
+            transaction = { block -> database.withTransaction { block() } }
         )
 
         allMeals = repository.allMeals
@@ -762,18 +766,13 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val timestamp = System.currentTimeMillis()
             val notes = "Logged from set: ${setWithItems.set.name}"
-            setWithItems.items.forEach { item ->
-                repository.insertMedication(
-                    MedicationEntry(
-                        name = item.name,
-                        dosage = item.dosage,
-                        notes = notes,
-                        timestamp = timestamp
-                    )
-                )
-            }
-            repository.insertMedicationSetLog(
-                MedicationSetLog(setId = setWithItems.set.id, timestamp = timestamp)
+            repository.logMedicationSetAtomically(
+                setId = setWithItems.set.id,
+                items = setWithItems.items.map {
+                    LogRepository.MedicationSetItemSpec(it.name, it.dosage)
+                },
+                timestamp = timestamp,
+                notes = notes
             )
             // Dismiss any pending notification for this set
             ReminderScheduler.dismissNotification(getApplication(), setWithItems.set.id)
@@ -811,34 +810,56 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     fun exportData(uri: Uri, onResult: (Boolean, String) -> Unit) {
         viewModelScope.launch {
             try {
+                // Read fresh from the repository Flows. The StateFlow mirrors use
+                // SharingStarted.Lazily, so they may still be empty if no screen has
+                // subscribed before the user triggers an export.
+                val meals = repository.allMeals.first()
+                val symptoms = repository.allSymptomEntries.first()
+                val bowelMovements = repository.allBowelMovements.first()
+                val medications = repository.allMedications.first()
+                val otherEntries = repository.allOtherEntries.first()
+                val bloodPressure = repository.allBloodPressureEntries.first()
+                val cholesterol = repository.allCholesterolEntries.first()
+                val weight = repository.allWeightEntries.first()
+                val spO2 = repository.allSpO2Entries.first()
+                val bloodGlucose = repository.allBloodGlucoseEntries.first()
+                val medicationSets = repository.allMedicationSets.first()
+                val cycleEntries = repository.allCycleEntries.first()
+                val stepCountEntries = repository.allStepCountEntries.first()
+                val remindersBySetId = repository.getAllReminders().first()
+                    .groupBy { it.setId }
                 val logsBySetId = repository.getAllMedicationSetLogs().first()
                     .groupBy { it.setId }
-                val json = DataExporter.export(
-                    meals = allMeals.value,
-                    symptoms = allSymptomEntries.value,
-                    bowelMovements = allBowelMovements.value,
-                    medications = allMedications.value,
-                    otherEntries = allOtherEntries.value,
-                    bloodPressureEntries = allBloodPressureEntries.value,
-                    cholesterolEntries = allCholesterolEntries.value,
-                    weightEntries = allWeightEntries.value,
-                    spO2Entries = allSpO2Entries.value,
-                    bloodGlucoseEntries = allBloodGlucoseEntries.value,
-                    medicationSets = allMedicationSets.value,
-                    remindersBySetId = allRemindersBySet.value,
-                    logsBySetId = logsBySetId,
-                    cycleEntries = allCycleEntries.value,
-                    stepCountEntries = allStepCountEntries.value
-                )
-                getApplication<Application>().contentResolver.openOutputStream(uri)?.use { stream ->
-                    stream.write(json.toByteArray())
+
+                val json = withContext(Dispatchers.IO) {
+                    DataExporter.export(
+                        meals = meals,
+                        symptoms = symptoms,
+                        bowelMovements = bowelMovements,
+                        medications = medications,
+                        otherEntries = otherEntries,
+                        bloodPressureEntries = bloodPressure,
+                        cholesterolEntries = cholesterol,
+                        weightEntries = weight,
+                        spO2Entries = spO2,
+                        bloodGlucoseEntries = bloodGlucose,
+                        medicationSets = medicationSets,
+                        remindersBySetId = remindersBySetId,
+                        logsBySetId = logsBySetId,
+                        cycleEntries = cycleEntries,
+                        stepCountEntries = stepCountEntries
+                    )
                 }
-                val total = allMeals.value.size + allSymptomEntries.value.size +
-                    allBowelMovements.value.size +
-                    allMedications.value.size + allOtherEntries.value.size +
-                    allBloodPressureEntries.value.size + allCholesterolEntries.value.size +
-                    allWeightEntries.value.size + allSpO2Entries.value.size +
-                    allBloodGlucoseEntries.value.size
+                withContext(Dispatchers.IO) {
+                    getApplication<Application>().contentResolver.openOutputStream(uri)
+                        ?.use { stream -> stream.write(json.toByteArray()) }
+                        ?: throw IllegalStateException("Could not open output stream")
+                }
+                val total = meals.size + symptoms.size + bowelMovements.size +
+                    medications.size + otherEntries.size +
+                    bloodPressure.size + cholesterol.size + weight.size + spO2.size +
+                    bloodGlucose.size + medicationSets.size +
+                    cycleEntries.size + stepCountEntries.size
                 onResult(true, "Exported $total entries successfully")
             } catch (e: Exception) {
                 onResult(false, "Export failed: ${e.message}")
@@ -849,8 +870,10 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
     fun importData(uri: Uri, onResult: (Boolean, String) -> Unit) {
         viewModelScope.launch {
             try {
-                val json = getApplication<Application>().contentResolver.openInputStream(uri)?.use { stream ->
-                    stream.bufferedReader().readText()
+                val json = withContext(Dispatchers.IO) {
+                    getApplication<Application>().contentResolver.openInputStream(uri)?.use { stream ->
+                        readJsonCapped(stream, MAX_IMPORT_BYTES)
+                    }
                 } ?: run {
                     onResult(false, "Could not read file")
                     return@launch
@@ -861,18 +884,52 @@ class LogViewModel(application: Application) : AndroidViewModel(application) {
                         if (result.medicationSetRemindersImported > 0) {
                             ReminderScheduler.rescheduleAllReminders(getApplication())
                         }
-                        onResult(true, "Imported ${result.totalImported} entries: " +
-                            "${result.mealsImported} meals, ${result.symptomsImported} symptoms, " +
-                            "${result.bowelMovementsImported} bowel movements, " +
-                            "${result.medicationsImported} medications, ${result.otherEntriesImported} other")
+                        val parts = buildList {
+                            add("${result.mealsImported} meals")
+                            add("${result.symptomsImported} symptoms")
+                            add("${result.bowelMovementsImported} bowel movements")
+                            add("${result.medicationsImported} medications")
+                            add("${result.otherEntriesImported} other")
+                            add("${result.bloodPressureImported} BP")
+                            add("${result.cholesterolImported} cholesterol")
+                            add("${result.weightImported} weight")
+                            add("${result.spO2Imported} SpO2")
+                            add("${result.bloodGlucoseImported} glucose")
+                            add("${result.medicationSetsImported} med sets")
+                            add("${result.cycleEntriesImported} cycle")
+                            add("${result.stepCountEntriesImported} steps")
+                        }
+                        onResult(true, "Imported ${result.totalImported} entries: " + parts.joinToString(", "))
                     }
                     is ImportResult.Error -> {
                         onResult(false, result.message)
                     }
                 }
+            } catch (e: ImportTooLargeException) {
+                onResult(false, "Import file too large (max ${MAX_IMPORT_BYTES / 1024 / 1024} MB)")
             } catch (e: Exception) {
                 onResult(false, "Import failed: ${e.message}")
             }
         }
+    }
+
+    private class ImportTooLargeException : RuntimeException()
+
+    private fun readJsonCapped(stream: java.io.InputStream, max: Long): String {
+        val out = java.io.ByteArrayOutputStream()
+        val buf = ByteArray(8 * 1024)
+        var total = 0L
+        while (true) {
+            val read = stream.read(buf)
+            if (read == -1) break
+            total += read
+            if (total > max) throw ImportTooLargeException()
+            out.write(buf, 0, read)
+        }
+        return out.toString(Charsets.UTF_8.name())
+    }
+
+    companion object {
+        private const val MAX_IMPORT_BYTES: Long = 50L * 1024 * 1024
     }
 }

--- a/app/src/test/java/com/privatehealthjournal/notification/ReminderSchedulerTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/notification/ReminderSchedulerTest.kt
@@ -1,0 +1,106 @@
+package com.privatehealthjournal.notification
+
+import com.privatehealthjournal.data.entity.DaysOfWeek
+import com.privatehealthjournal.data.entity.MedicationSetReminder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+class ReminderSchedulerTest {
+
+    private fun millis(year: Int, month: Int, day: Int, hour: Int, minute: Int): Long {
+        // month is 1-based for readability; Calendar.MONTH is 0-based.
+        val cal = Calendar.getInstance(TimeZone.getDefault())
+        cal.clear()
+        cal.set(year, month - 1, day, hour, minute, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return cal.timeInMillis
+    }
+
+    private fun reminder(hour: Int, minute: Int, days: Int) =
+        MedicationSetReminder(id = 1, setId = 1, hour = hour, minute = minute, daysOfWeek = days)
+
+    @Test
+    fun `every-day reminder, time later today, schedules today`() {
+        // 2026-03-04 was a Wednesday.
+        val now = millis(2026, 3, 4, 7, 0)
+        val expected = millis(2026, 3, 4, 8, 30)
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 8, minute = 30, days = DaysOfWeek.EVERY_DAY),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `every-day reminder, time already passed today, schedules tomorrow`() {
+        val now = millis(2026, 3, 4, 9, 0)
+        val expected = millis(2026, 3, 5, 8, 30)
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 8, minute = 30, days = DaysOfWeek.EVERY_DAY),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `weekday-only reminder skips weekend`() {
+        // Friday 2026-03-06 at 20:00, reminder Mon-Fri at 09:00 — next slot is Monday 2026-03-09.
+        val weekdays = DaysOfWeek.MONDAY or DaysOfWeek.TUESDAY or DaysOfWeek.WEDNESDAY or
+            DaysOfWeek.THURSDAY or DaysOfWeek.FRIDAY
+        val now = millis(2026, 3, 6, 20, 0)
+        val expected = millis(2026, 3, 9, 9, 0)
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 9, minute = 0, days = weekdays),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `weekend-only reminder from Wednesday picks Saturday`() {
+        val weekend = DaysOfWeek.SATURDAY or DaysOfWeek.SUNDAY
+        val now = millis(2026, 3, 4, 10, 0) // Wednesday
+        val expected = millis(2026, 3, 7, 10, 0) // Saturday
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 10, minute = 0, days = weekend),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `same-day enabled but past time wraps to next enabled day`() {
+        // Wednesday-only reminder, currently Wednesday past the trigger time → next Wednesday.
+        val now = millis(2026, 3, 4, 12, 0) // Wednesday
+        val expected = millis(2026, 3, 11, 8, 0) // Following Wednesday
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 8, minute = 0, days = DaysOfWeek.WEDNESDAY),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `no days enabled falls back to tomorrow same time`() {
+        val now = millis(2026, 3, 4, 12, 0)
+        val expected = millis(2026, 3, 5, 8, 0)
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 8, minute = 0, days = 0),
+            now
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `every-day reminder always lands in the future`() {
+        val now = millis(2026, 3, 4, 23, 59)
+        val actual = ReminderScheduler.computeNextTriggerTime(
+            reminder(hour = 0, minute = 0, days = DaysOfWeek.EVERY_DAY),
+            now
+        )
+        assertTrue("trigger must be after now", actual > now)
+    }
+}


### PR DESCRIPTION
- LogRepository.logMedicationSetAtomically: wrap N MedicationEntry inserts + the MedicationSetLog row in a single Room transaction so a crash mid-loop can no longer leave orphan medication rows with no set-log (which would re-fire the same-day reminder). Repository takes an optional `transaction` lambda; MainActivity and LogViewModel pass `db.withTransaction`, tests get a no-op default.
- LogViewModel.exportData: read entries via repository.allXxx.first() instead of the StateFlow mirrors (which are SharingStarted.Lazily and may still be empty on a fresh launch, silently producing an empty export). JSON serialization and the SAF write now run on Dispatchers.IO.
- LogViewModel.importData: cap input at 50MB to prevent OOM/DoS from a crafted JSON file; read on Dispatchers.IO; surface every entity type's count in the success toast (previously biometrics, cycle, steps, sets, reminders were silently omitted).
- ReminderBroadcastReceiver + MainActivity channel: mark medication reminder notifications VISIBILITY_PRIVATE with a generic public version so the set name (which can disclose a sensitive condition) is not shown on a secure lockscreen.
- ReminderScheduler.computeNextTriggerTime: extract a pure overload taking nowMillis so the day-wrap, all-days-off, and "today's slot already passed" branches are unit-testable without the system clock. Add ReminderSchedulerTest covering those cases.