### PR TITLE
perf+ux: index timestamps, key lists, save form state, fix new-intent…

### DIFF
--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -3,6 +3,7 @@ package com.privatehealthjournal
 import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -46,7 +47,8 @@ import com.privatehealthjournal.sensor.StepSync
 import com.privatehealthjournal.ui.theme.PrivateHealthJournalTheme
 import com.privatehealthjournal.viewmodel.LogViewModel
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -54,6 +56,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.room.withTransaction
 import com.privatehealthjournal.data.AppDatabase
 import com.privatehealthjournal.data.repository.LogRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -63,6 +66,14 @@ class MainActivity : ComponentActivity() {
     ) { _: Boolean -> }
 
     private lateinit var stepSync: StepSync
+
+    private val pendingNavigation = MutableStateFlow<String?>(null)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingNavigation.value = intent.getStringExtra("navigate_to")?.takeIf { it in ALLOWED_NAV_ROUTES }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -81,7 +92,9 @@ class MainActivity : ComponentActivity() {
         )
         stepSync = StepSync.create(applicationContext, syncRepo)
 
-        val navigateTo = intent?.getStringExtra("navigate_to")
+        pendingNavigation.value = intent
+            ?.getStringExtra("navigate_to")
+            ?.takeIf { it in ALLOWED_NAV_ROUTES }
 
         setContent {
             PrivateHealthJournalTheme {
@@ -103,10 +116,11 @@ class MainActivity : ComponentActivity() {
                         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
                     }
 
-                    LaunchedEffect(navigateTo) {
-                        if (navigateTo != null) {
-                            navController.navigate(navigateTo)
-                        }
+                    val pending by pendingNavigation.collectAsState()
+                    LaunchedEffect(pending) {
+                        val route = pending ?: return@LaunchedEffect
+                        navController.navigate(route)
+                        pendingNavigation.value = null
                     }
 
                     NavHost(
@@ -491,5 +505,15 @@ class MainActivity : ComponentActivity() {
                 requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
+    }
+
+    companion object {
+        // Whitelist of routes accepted via the `navigate_to` intent extra. Limited to
+        // no-arg top-level destinations — parameterized edit_*/{id} routes carry IDs and
+        // would need stricter validation if ever exposed via deep links.
+        private val ALLOWED_NAV_ROUTES = setOf(
+            "home", "history", "calendar", "settings",
+            "medication_sets", "biometrics_chart", "meal_budget", "cycle_tracking"
+        )
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/AppDatabase.kt
@@ -63,7 +63,7 @@ import com.privatehealthjournal.data.entity.WeightEntry
         CycleEntry::class,
         StepCountEntry::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -186,6 +186,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Every entry-list query does `ORDER BY <time> DESC`. Add a covering
+                // index so it doesn't require a full-table sort.
+                val tablesByTimestamp = listOf(
+                    "meal_entries", "bowel_movement_entries",
+                    "medication_entries", "other_entries", "blood_pressure_entries",
+                    "cholesterol_entries", "weight_entries", "spo2_entries",
+                    "blood_glucose_entries", "cycle_entries", "medication_set_logs"
+                )
+                tablesByTimestamp.forEach { table ->
+                    database.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_${table}_timestamp` ON `$table` (`timestamp`)"
+                    )
+                }
+                // symptom_entries sorts by startTime (no timestamp column)
+                database.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_symptom_entries_startTime` ON `symptom_entries` (`startTime`)"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -193,7 +215,10 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "private_health_journal_database"
                 )
-                    .addMigrations(MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
+                    .addMigrations(
+                        MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12,
+                        MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15
+                    )
                     .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance

--- a/app/src/main/java/com/privatehealthjournal/data/entity/BloodGlucoseEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/BloodGlucoseEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class GlucoseUnit(val displayLabel: String) {
@@ -15,7 +16,7 @@ enum class GlucoseMealContext(val displayLabel: String) {
     BEDTIME("Bedtime")
 }
 
-@Entity(tableName = "blood_glucose_entries")
+@Entity(tableName = "blood_glucose_entries", indices = [Index("timestamp")])
 data class BloodGlucoseEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/BloodPressureEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/BloodPressureEntry.kt
@@ -1,9 +1,10 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "blood_pressure_entries")
+@Entity(tableName = "blood_pressure_entries", indices = [Index("timestamp")])
 data class BloodPressureEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/BowelMovementEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/BowelMovementEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class BristolType(val type: Int, val displayName: String, val description: String) {
@@ -17,7 +18,7 @@ enum class BristolType(val type: Int, val displayName: String, val description: 
     }
 }
 
-@Entity(tableName = "bowel_movement_entries")
+@Entity(tableName = "bowel_movement_entries", indices = [Index("timestamp")])
 data class BowelMovementEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/CholesterolEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/CholesterolEntry.kt
@@ -1,9 +1,10 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "cholesterol_entries")
+@Entity(tableName = "cholesterol_entries", indices = [Index("timestamp")])
 data class CholesterolEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/CycleEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/CycleEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class FlowIntensity(val displayLabel: String) {
@@ -28,7 +29,7 @@ enum class CycleSymptom(val displayLabel: String) {
     }
 }
 
-@Entity(tableName = "cycle_entries")
+@Entity(tableName = "cycle_entries", indices = [Index("timestamp")])
 data class CycleEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MealEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MealEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class MealType {
@@ -10,7 +11,7 @@ enum class MealType {
     SNACK
 }
 
-@Entity(tableName = "meal_entries")
+@Entity(tableName = "meal_entries", indices = [Index("timestamp")])
 data class MealEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MedicationEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MedicationEntry.kt
@@ -1,9 +1,10 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "medication_entries")
+@Entity(tableName = "medication_entries", indices = [Index("timestamp")])
 data class MedicationEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetLog.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/MedicationSetLog.kt
@@ -15,7 +15,7 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("setId")]
+    indices = [Index("setId"), Index("timestamp")]
 )
 data class MedicationSetLog(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/com/privatehealthjournal/data/entity/OtherEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/OtherEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class OtherEntryType {
@@ -13,7 +14,7 @@ enum class OtherEntryType {
     OTHER
 }
 
-@Entity(tableName = "other_entries")
+@Entity(tableName = "other_entries", indices = [Index("timestamp")])
 data class OtherEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/SpO2Entry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/SpO2Entry.kt
@@ -1,9 +1,10 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "spo2_entries")
+@Entity(tableName = "spo2_entries", indices = [Index("timestamp")])
 data class SpO2Entry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/SymptomEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/SymptomEntry.kt
@@ -1,9 +1,10 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "symptom_entries")
+@Entity(tableName = "symptom_entries", indices = [Index("startTime")])
 data class SymptomEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/data/entity/WeightEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/data/entity/WeightEntry.kt
@@ -1,6 +1,7 @@
 package com.privatehealthjournal.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 enum class WeightUnit {
@@ -8,7 +9,7 @@ enum class WeightUnit {
     KG
 }
 
-@Entity(tableName = "weight_entries")
+@Entity(tableName = "weight_entries", indices = [Index("timestamp")])
 data class WeightEntry(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -53,12 +54,12 @@ fun AddBloodGlucoseScreen(
     val editingEntry by viewModel.editingBloodGlucose.collectAsState()
     val isEditMode = editId != null
 
-    var glucoseLevel by remember { mutableStateOf("") }
-    var unit by remember { mutableStateOf(GlucoseUnit.MG_DL) }
-    var mealContext by remember { mutableStateOf<GlucoseMealContext?>(null) }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var glucoseLevel by rememberSaveable { mutableStateOf("") }
+    var unit by rememberSaveable { mutableStateOf(GlucoseUnit.MG_DL) }
+    var mealContext by rememberSaveable { mutableStateOf<GlucoseMealContext?>(null) }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -50,12 +51,12 @@ fun AddBloodPressureScreen(
     val editingEntry by viewModel.editingBloodPressure.collectAsState()
     val isEditMode = editId != null
 
-    var systolic by remember { mutableStateOf("") }
-    var diastolic by remember { mutableStateOf("") }
-    var pulse by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var systolic by rememberSaveable { mutableStateOf("") }
+    var diastolic by rememberSaveable { mutableStateOf("") }
+    var pulse by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,10 +59,10 @@ fun AddBowelMovementScreen(
     val editingBowelMovement by viewModel.editingBowelMovement.collectAsState()
     val isEditMode = editId != null
 
-    var selectedType by remember { mutableIntStateOf(4) }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var selectedType by rememberSaveable { mutableIntStateOf(4) }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     // Load existing entry for editing
     LaunchedEffect(editId) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -50,13 +51,13 @@ fun AddCholesterolScreen(
     val editingEntry by viewModel.editingCholesterol.collectAsState()
     val isEditMode = editId != null
 
-    var total by remember { mutableStateOf("") }
-    var ldl by remember { mutableStateOf("") }
-    var hdl by remember { mutableStateOf("") }
-    var triglycerides by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var total by rememberSaveable { mutableStateOf("") }
+    var ldl by rememberSaveable { mutableStateOf("") }
+    var hdl by rememberSaveable { mutableStateOf("") }
+    var triglycerides by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,11 +57,11 @@ fun AddCycleEntryScreen(
     val editingEntry by viewModel.editingCycleEntry.collectAsState()
     val isEditMode = editId != null
 
-    var selectedFlow by remember { mutableStateOf(FlowIntensity.MEDIUM) }
-    var selectedSymptoms by remember { mutableStateOf(emptySet<CycleSymptom>()) }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var selectedFlow by rememberSaveable { mutableStateOf(FlowIntensity.MEDIUM) }
+    var selectedSymptoms by rememberSaveable { mutableStateOf(emptySet<CycleSymptom>()) }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,15 +73,15 @@ fun AddMealScreen(
         try { MealType.valueOf(it) } catch (e: IllegalArgumentException) { MealType.BREAKFAST }
     } ?: MealType.BREAKFAST
 
-    var selectedMealType by remember { mutableStateOf(initialMealType) }
+    var selectedMealType by rememberSaveable { mutableStateOf(initialMealType) }
     val foods = remember { mutableStateListOf<String>() }
-    var currentFood by remember { mutableStateOf("") }
+    var currentFood by rememberSaveable { mutableStateOf("") }
     val tags = remember { mutableStateListOf<String>() }
-    var currentTag by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var pointCostText by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var currentTag by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var pointCostText by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     val existingTags by viewModel.allTags.collectAsState()
     val foodNames by viewModel.allFoodNames.collectAsState()

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -54,11 +55,11 @@ fun AddMedicationScreen(
     val medicationNames by viewModel.allMedicationNames.collectAsState()
     val isEditMode = editId != null
 
-    var name by remember { mutableStateOf(prefillName ?: "") }
-    var dosage by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var name by rememberSaveable { mutableStateOf(prefillName ?: "") }
+    var dosage by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     // Load existing entry for editing
     LaunchedEffect(editId) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,9 +64,9 @@ fun AddMedicationSetScreen(
     val medicationNames by viewModel.allMedicationNames.collectAsState()
     val isEditMode = editId != null
 
-    var setName by remember { mutableStateOf("") }
+    var setName by rememberSaveable { mutableStateOf("") }
     val items = remember { mutableStateListOf(MedItemState()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,16 +76,16 @@ fun AddOtherEntryScreen(
         try { OtherEntryType.valueOf(it) } catch (e: IllegalArgumentException) { OtherEntryType.BOWEL_MOVEMENT }
     } ?: OtherEntryType.BOWEL_MOVEMENT
 
-    var selectedType by remember { mutableStateOf(initialType) }
-    var subType by remember { mutableStateOf("") }
-    var value by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var pointCreditText by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var selectedType by rememberSaveable { mutableStateOf(initialType) }
+    var subType by rememberSaveable { mutableStateOf("") }
+    var value by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var pointCreditText by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     // For bowel movement Bristol scale
-    var selectedBristolType by remember { mutableIntStateOf(4) }
+    var selectedBristolType by rememberSaveable { mutableIntStateOf(4) }
 
     // Load existing entry for editing
     LaunchedEffect(editId) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -48,11 +49,11 @@ fun AddSpO2Screen(
     val editingEntry by viewModel.editingSpO2.collectAsState()
     val isEditMode = editId != null
 
-    var spo2 by remember { mutableStateOf("") }
-    var pulse by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var spo2 by rememberSaveable { mutableStateOf("") }
+    var pulse by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,9 +60,11 @@ fun AddStepCountScreen(
     val editingEntry by viewModel.editingStepCount.collectAsState()
     val isEditMode = editId != null
 
-    var steps by remember { mutableStateOf("") }
-    var notes by remember { mutableStateOf("") }
-    var dateMillis by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var steps by rememberSaveable { mutableStateOf("") }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var dateMillis by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    // existingEntry / showDatePicker stay on `remember` — StepCountEntry has no Saver and
+    // the picker flag is transient UI state.
     var existingEntry by remember { mutableStateOf<StepCountEntry?>(null) }
     var showDatePicker by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,15 +63,15 @@ fun AddSymptomScreen(
     val symptomNames by viewModel.allSymptomNames.collectAsState()
     val isEditMode = editId != null
 
-    var symptomName by remember { mutableStateOf(prefillName ?: "") }
-    var severity by remember { mutableFloatStateOf(3f) }
-    var notes by remember { mutableStateOf("") }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var symptomName by rememberSaveable { mutableStateOf(prefillName ?: "") }
+    var severity by rememberSaveable { mutableFloatStateOf(3f) }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     val currentTime = System.currentTimeMillis()
-    var startTime by remember { mutableLongStateOf(currentTime) }
-    var hasEndTime by remember { mutableStateOf(false) }
-    var endTime by remember { mutableLongStateOf(currentTime) }
+    var startTime by rememberSaveable { mutableLongStateOf(currentTime) }
+    var hasEndTime by rememberSaveable { mutableStateOf(false) }
+    var endTime by rememberSaveable { mutableLongStateOf(currentTime) }
 
     // Load existing entry for editing
     LaunchedEffect(editId) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -54,11 +55,11 @@ fun AddWeightScreen(
     val editingEntry by viewModel.editingWeight.collectAsState()
     val isEditMode = editId != null
 
-    var weight by remember { mutableStateOf("") }
-    var unit by remember { mutableStateOf(WeightUnit.LB) }
-    var notes by remember { mutableStateOf("") }
-    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    var existingId by remember { mutableStateOf<Long?>(null) }
+    var weight by rememberSaveable { mutableStateOf("") }
+    var unit by rememberSaveable { mutableStateOf(WeightUnit.LB) }
+    var notes by rememberSaveable { mutableStateOf("") }
+    var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
+    var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(editId) {
         if (editId != null) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
@@ -261,7 +261,10 @@ fun CalendarScreen(
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    items(selectedEntries) { entry ->
+                    items(
+                        selectedEntries,
+                        key = { entry -> "${entry::class.simpleName}-${entry.entryId}" }
+                    ) { entry ->
                         when (entry) {
                             is CalendarEntry.Meal -> MealEntryCard(
                                 meal = entry.entry,
@@ -491,15 +494,39 @@ private fun CalendarDayCell(
 }
 
 private sealed class CalendarEntry {
-    data class Meal(val entry: MealWithDetails) : CalendarEntry()
-    data class Symptom(val entry: SymptomEntry) : CalendarEntry()
-    data class Medication(val entry: MedicationEntry) : CalendarEntry()
-    data class Other(val entry: OtherEntry) : CalendarEntry()
-    data class BloodPressure(val entry: BloodPressureEntry) : CalendarEntry()
-    data class Cholesterol(val entry: CholesterolEntry) : CalendarEntry()
-    data class Weight(val entry: WeightEntry) : CalendarEntry()
-    data class SpO2(val entry: SpO2Entry) : CalendarEntry()
-    data class BloodGlucose(val entry: BloodGlucoseEntry) : CalendarEntry()
-    data class Cycle(val entry: CycleEntry) : CalendarEntry()
-    data class StepCount(val entry: StepCountEntry) : CalendarEntry()
+    abstract val entryId: Long
+
+    data class Meal(val entry: MealWithDetails) : CalendarEntry() {
+        override val entryId: Long = entry.meal.id
+    }
+    data class Symptom(val entry: SymptomEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class Medication(val entry: MedicationEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class Other(val entry: OtherEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class BloodPressure(val entry: BloodPressureEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class Cholesterol(val entry: CholesterolEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class Weight(val entry: WeightEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class SpO2(val entry: SpO2Entry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class BloodGlucose(val entry: BloodGlucoseEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class Cycle(val entry: CycleEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
+    data class StepCount(val entry: StepCountEntry) : CalendarEntry() {
+        override val entryId: Long = entry.id
+    }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
@@ -170,40 +170,46 @@ fun HistoryScreen(
                 }
             }
 
-            val filteredEntries = when (filterType) {
-                FilterType.ALL -> {
-                    (allMeals.map { HistoryEntry.Meal(it) } +
-                            allSymptoms.map { HistoryEntry.Symptom(it) } +
-                            allMedications.map { HistoryEntry.Medication(it) } +
-                            allOtherEntries.map { HistoryEntry.Other(it) } +
-                            allBloodPressure.map { HistoryEntry.BloodPressure(it) } +
-                            allCholesterol.map { HistoryEntry.Cholesterol(it) } +
-                            allWeight.map { HistoryEntry.Weight(it) } +
-                            allSpO2.map { HistoryEntry.SpO2(it) } +
-                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
-                            (if (showCycleTracking) allCycleEntries.map { HistoryEntry.Cycle(it) } else emptyList()) +
-                            (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
+            val filteredEntries = remember(
+                filterType, allMeals, allSymptoms, allMedications, allOtherEntries,
+                allBloodPressure, allCholesterol, allWeight, allSpO2, allBloodGlucose,
+                allCycleEntries, allStepCountEntries, showCycleTracking, showStepCounting
+            ) {
+                when (filterType) {
+                    FilterType.ALL -> {
+                        (allMeals.map { HistoryEntry.Meal(it) } +
+                                allSymptoms.map { HistoryEntry.Symptom(it) } +
+                                allMedications.map { HistoryEntry.Medication(it) } +
+                                allOtherEntries.map { HistoryEntry.Other(it) } +
+                                allBloodPressure.map { HistoryEntry.BloodPressure(it) } +
+                                allCholesterol.map { HistoryEntry.Cholesterol(it) } +
+                                allWeight.map { HistoryEntry.Weight(it) } +
+                                allSpO2.map { HistoryEntry.SpO2(it) } +
+                                allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
+                                (if (showCycleTracking) allCycleEntries.map { HistoryEntry.Cycle(it) } else emptyList()) +
+                                (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
+                            .sortedByDescending { it.timestamp }
+                    }
+                    FilterType.MEALS -> allMeals.map { HistoryEntry.Meal(it) }
+                        .sortedByDescending { it.timestamp }
+                    FilterType.SYMPTOMS -> allSymptoms.map { HistoryEntry.Symptom(it) }
+                        .sortedByDescending { it.timestamp }
+                    FilterType.OTHER -> allOtherEntries.map { HistoryEntry.Other(it) }
+                        .sortedByDescending { it.timestamp }
+                    FilterType.MEDICATIONS -> allMedications.map { HistoryEntry.Medication(it) }
+                        .sortedByDescending { it.timestamp }
+                    FilterType.BIOMETRICS -> {
+                        (allBloodPressure.map { HistoryEntry.BloodPressure(it) } +
+                                allCholesterol.map { HistoryEntry.Cholesterol(it) } +
+                                allWeight.map { HistoryEntry.Weight(it) } +
+                                allSpO2.map { HistoryEntry.SpO2(it) } +
+                                allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
+                                (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
+                            .sortedByDescending { it.timestamp }
+                    }
+                    FilterType.CYCLE -> allCycleEntries.map { HistoryEntry.Cycle(it) }
                         .sortedByDescending { it.timestamp }
                 }
-                FilterType.MEALS -> allMeals.map { HistoryEntry.Meal(it) }
-                    .sortedByDescending { it.timestamp }
-                FilterType.SYMPTOMS -> allSymptoms.map { HistoryEntry.Symptom(it) }
-                    .sortedByDescending { it.timestamp }
-                FilterType.OTHER -> allOtherEntries.map { HistoryEntry.Other(it) }
-                    .sortedByDescending { it.timestamp }
-                FilterType.MEDICATIONS -> allMedications.map { HistoryEntry.Medication(it) }
-                    .sortedByDescending { it.timestamp }
-                FilterType.BIOMETRICS -> {
-                    (allBloodPressure.map { HistoryEntry.BloodPressure(it) } +
-                            allCholesterol.map { HistoryEntry.Cholesterol(it) } +
-                            allWeight.map { HistoryEntry.Weight(it) } +
-                            allSpO2.map { HistoryEntry.SpO2(it) } +
-                            allBloodGlucose.map { HistoryEntry.BloodGlucose(it) } +
-                            (if (showStepCounting) allStepCountEntries.map { HistoryEntry.StepCount(it) } else emptyList()))
-                        .sortedByDescending { it.timestamp }
-                }
-                FilterType.CYCLE -> allCycleEntries.map { HistoryEntry.Cycle(it) }
-                    .sortedByDescending { it.timestamp }
             }
 
             if (filteredEntries.isEmpty()) {
@@ -220,9 +226,12 @@ fun HistoryScreen(
                     )
                 }
             } else {
-                // Group entries by day
-                val entriesByDay = filteredEntries.groupBy { entry ->
-                    Instant.ofEpochMilli(entry.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
+                val entriesByDay = remember(filteredEntries) {
+                    filteredEntries.groupBy { entry ->
+                        Instant.ofEpochMilli(entry.timestamp)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDate()
+                    }
                 }
 
                 val today = LocalDate.now()
@@ -262,7 +271,10 @@ fun HistoryScreen(
                                 )
                             }
                         }
-                        items(entries) { entry ->
+                        items(
+                            entries,
+                            key = { entry -> "${entry::class.simpleName}-${entry.entryId}" }
+                        ) { entry ->
                             when (entry) {
                                 is HistoryEntry.Meal -> MealEntryCard(
                                     meal = entry.entry,
@@ -334,45 +346,56 @@ fun HistoryScreen(
 
 private sealed class HistoryEntry {
     abstract val timestamp: Long
+    abstract val entryId: Long
 
     data class Meal(val entry: MealWithDetails) : HistoryEntry() {
         override val timestamp: Long = entry.meal.timestamp
+        override val entryId: Long = entry.meal.id
     }
 
     data class Symptom(val entry: SymptomEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class Other(val entry: OtherEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class Medication(val entry: MedicationEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class BloodPressure(val entry: BloodPressureEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class Cholesterol(val entry: CholesterolEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class Weight(val entry: WeightEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class SpO2(val entry: SpO2Entry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class BloodGlucose(val entry: BloodGlucoseEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class Cycle(val entry: CycleEntry) : HistoryEntry() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
 
     data class StepCount(val entry: StepCountEntry) : HistoryEntry() {
@@ -381,5 +404,6 @@ private sealed class HistoryEntry {
                 .atStartOfDay(ZoneId.systemDefault())
                 .toInstant()
                 .toEpochMilli()
+        override val entryId: Long = entry.id
     }
 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -485,25 +485,32 @@ fun HomeScreen(
                     )
                 }
             } else {
-                val combinedEntries = (
-                    recentMeals.map { EntryItem.Meal(it) } +
-                    recentSymptoms.map { EntryItem.Symptom(it) } +
-                    recentMedications.map { EntryItem.Medication(it) } +
-                    recentOtherEntries.map { EntryItem.Other(it) } +
-                    recentBloodPressure.map { EntryItem.BloodPressure(it) } +
-                    recentCholesterol.map { EntryItem.Cholesterol(it) } +
-                    recentWeight.map { EntryItem.Weight(it) } +
-                    recentSpO2.map { EntryItem.SpO2(it) } +
-                    recentBloodGlucose.map { EntryItem.BloodGlucose(it) } +
-                    (if (showCycleTracking) recentCycleEntries.map { EntryItem.Cycle(it) } else emptyList()) +
-                    (if (showStepCounting) recentStepCount.map { EntryItem.StepCount(it) } else emptyList())
-                )
-                    .sortedByDescending { it.timestamp }
-                    .take(10)
-
-                // Group entries by day
-                val entriesByDay = combinedEntries.groupBy { item ->
-                    Instant.ofEpochMilli(item.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
+                val entriesByDay = remember(
+                    recentMeals, recentSymptoms, recentMedications, recentOtherEntries,
+                    recentBloodPressure, recentCholesterol, recentWeight, recentSpO2,
+                    recentBloodGlucose, recentCycleEntries, recentStepCount,
+                    showCycleTracking, showStepCounting
+                ) {
+                    val combined = (
+                        recentMeals.map { EntryItem.Meal(it) } +
+                        recentSymptoms.map { EntryItem.Symptom(it) } +
+                        recentMedications.map { EntryItem.Medication(it) } +
+                        recentOtherEntries.map { EntryItem.Other(it) } +
+                        recentBloodPressure.map { EntryItem.BloodPressure(it) } +
+                        recentCholesterol.map { EntryItem.Cholesterol(it) } +
+                        recentWeight.map { EntryItem.Weight(it) } +
+                        recentSpO2.map { EntryItem.SpO2(it) } +
+                        recentBloodGlucose.map { EntryItem.BloodGlucose(it) } +
+                        (if (showCycleTracking) recentCycleEntries.map { EntryItem.Cycle(it) } else emptyList()) +
+                        (if (showStepCounting) recentStepCount.map { EntryItem.StepCount(it) } else emptyList())
+                    )
+                        .sortedByDescending { it.timestamp }
+                        .take(10)
+                    combined.groupBy { item ->
+                        Instant.ofEpochMilli(item.timestamp)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDate()
+                    }
                 }
 
                 val today = LocalDate.now()
@@ -542,7 +549,10 @@ fun HomeScreen(
                                 )
                             }
                         }
-                        items(entries) { item ->
+                        items(
+                            entries,
+                            key = { item -> "${item::class.simpleName}-${item.entryId}" }
+                        ) { item ->
                             when (item) {
                                 is EntryItem.Meal -> MealEntryCard(
                                     meal = item.entry,
@@ -614,36 +624,47 @@ fun HomeScreen(
 
 private sealed class EntryItem {
     abstract val timestamp: Long
+    abstract val entryId: Long
 
     data class Meal(val entry: MealWithDetails) : EntryItem() {
         override val timestamp: Long = entry.meal.timestamp
+        override val entryId: Long = entry.meal.id
     }
     data class Symptom(val entry: SymptomEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class Medication(val entry: MedicationEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class Other(val entry: OtherEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class BloodPressure(val entry: BloodPressureEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class Cholesterol(val entry: CholesterolEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class Weight(val entry: WeightEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class SpO2(val entry: SpO2Entry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class BloodGlucose(val entry: BloodGlucoseEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class Cycle(val entry: CycleEntry) : EntryItem() {
         override val timestamp: Long = entry.timestamp
+        override val entryId: Long = entry.id
     }
     data class StepCount(val entry: StepCountEntry) : EntryItem() {
         override val timestamp: Long =
@@ -651,5 +672,6 @@ private sealed class EntryItem {
                 .atStartOfDay(ZoneId.systemDefault())
                 .toInstant()
                 .toEpochMilli()
+        override val entryId: Long = entry.id
     }
 }


### PR DESCRIPTION
… routing

- AppDatabase v14 → v15. Add @Index on the time column of every entry table (timestamp on 11 entities, startTime on SymptomEntry, which has no timestamp column) and on medication_set_logs.timestamp. MIGRATION_14_15 creates the matching SQL indexes so existing DBs are not destroyed. Every DAO does ORDER BY <time> DESC; these queries no longer require a full-table sort.
- HomeScreen / HistoryScreen / CalendarScreen: pass a stable `key = { "${item::class.simpleName}-${item.entryId}" }` to LazyColumn items(). Two sealed-class subtypes can share a numeric id (Meal#1 vs Symptom#1) — namespace by subtype to avoid card state being reused across types.
- HomeScreen.combinedEntries + entriesByDay and HistoryScreen.filteredEntries are now produced inside `remember(...)` keyed on every source list + filter. CalendarScreen already memoized its heavy map.
- All 13 Add*Screen.kt files switch primitive form vars from `remember { mutableStateOf(...) }` to `rememberSaveable { mutableStateOf(...) }` so typed input + selected enums survive rotation / process death. Non-Parcelable Entity vars (e.g. existingEntry: StepCountEntry?) and transient UI flags stay on `remember`.
- MainActivity: override onNewIntent so notification taps work while the app is already running. The navigate_to extra is now routed through a private MutableStateFlow consumed by the existing LaunchedEffect, and validated against an ALLOWED_NAV_ROUTES whitelist so an arbitrary app can't deep-link to internal parameterized routes via the launcher extra.

The reviewer also flagged updateSetWithItems delete-then-reinsert as a risk; investigation showed no foreign keys reference medication_set_items.id, so nothing breaks. Left unchanged.