### PR TITLE
refactor: shrink Add screens, NavIntent, deprecation cleanup, in-memory tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,8 +109,11 @@ dependencies {
     testImplementation("com.google.truth:truth:1.1.5")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+    androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation(platform("androidx.compose:compose-bom:2026.05.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.room:room-testing:2.8.4")
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/androidTest/java/com/privatehealthjournal/data/dao/MealDaoTest.kt
+++ b/app/src/androidTest/java/com/privatehealthjournal/data/dao/MealDaoTest.kt
@@ -1,0 +1,70 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.privatehealthjournal.data.AppDatabase
+import com.privatehealthjournal.data.entity.MealEntry
+import com.privatehealthjournal.data.entity.MealType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MealDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: MealDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.mealDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertMealWithDetails_persistsMealFoodsAndTagsAtomically() = runTest {
+        val mealId = dao.insertMealWithDetails(
+            meal = MealEntry(mealType = MealType.LUNCH, notes = "Filling"),
+            foods = listOf("Salad", "Bread"),
+            tagNames = listOf("homemade", "low-carb")
+        )
+
+        val loaded = dao.getMealWithDetailsById(mealId)
+        assertNotNull(loaded)
+        assertEquals(MealType.LUNCH, loaded!!.meal.mealType)
+        assertEquals("Filling", loaded.meal.notes)
+        assertEquals(setOf("Salad", "Bread"), loaded.foods.map { it.name }.toSet())
+        assertEquals(setOf("homemade", "low-carb"), loaded.tags.map { it.name }.toSet())
+    }
+
+    @Test
+    fun insertMealWithDetails_reusesExistingTagRows() = runTest {
+        dao.insertMealWithDetails(
+            MealEntry(mealType = MealType.BREAKFAST),
+            foods = listOf("Eggs"),
+            tagNames = listOf("protein")
+        )
+        dao.insertMealWithDetails(
+            MealEntry(mealType = MealType.DINNER),
+            foods = listOf("Chicken"),
+            tagNames = listOf("protein") // same tag name
+        )
+
+        // The Tag should exist exactly once; two meals link to it via cross-ref.
+        val tag = dao.getTagByName("protein")
+        assertNotNull(tag)
+    }
+}

--- a/app/src/androidTest/java/com/privatehealthjournal/data/dao/MedicationSetDaoTest.kt
+++ b/app/src/androidTest/java/com/privatehealthjournal/data/dao/MedicationSetDaoTest.kt
@@ -1,0 +1,86 @@
+package com.privatehealthjournal.data.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.privatehealthjournal.data.AppDatabase
+import com.privatehealthjournal.data.entity.MedicationSet
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MedicationSetDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: MedicationSetDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.medicationSetDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertSetWithItems_persistsSetAndItemsAtomically() = runTest {
+        val items = listOf("Metformin" to "500mg", "Atorvastatin" to "20mg")
+
+        val setId = dao.insertSetWithItems(MedicationSet(name = "Morning"), items)
+
+        val loaded = dao.getSetWithItemsById(setId)
+        assertNotNull(loaded)
+        assertEquals("Morning", loaded!!.set.name)
+        assertEquals(2, loaded.items.size)
+        assertEquals(setOf("Metformin", "Atorvastatin"), loaded.items.map { it.name }.toSet())
+        assertEquals(setOf("500mg", "20mg"), loaded.items.map { it.dosage }.toSet())
+    }
+
+    @Test
+    fun updateSetWithItems_replacesItems() = runTest {
+        val setId = dao.insertSetWithItems(
+            MedicationSet(name = "Morning"),
+            listOf("Old" to "1mg")
+        )
+
+        dao.updateSetWithItems(
+            MedicationSet(id = setId, name = "Morning Renamed"),
+            listOf("New A" to "10mg", "New B" to "20mg")
+        )
+
+        val loaded = dao.getSetWithItemsById(setId)
+        assertNotNull(loaded)
+        assertEquals("Morning Renamed", loaded!!.set.name)
+        assertEquals(2, loaded.items.size)
+        assertEquals(setOf("New A", "New B"), loaded.items.map { it.name }.toSet())
+    }
+
+    @Test
+    fun deleteSet_cascadesToItems() = runTest {
+        val setId = dao.insertSetWithItems(
+            MedicationSet(name = "Doomed"),
+            listOf("A" to "1mg", "B" to "2mg")
+        )
+        val set = dao.getSetWithItemsById(setId)!!.set
+
+        dao.deleteSet(set)
+
+        assertNull(dao.getSetWithItemsById(setId))
+        // All cross-rows for the set should be gone via ON DELETE CASCADE.
+        val remaining = dao.getAllSetsWithItems().first()
+        assertEquals(0, remaining.size)
+    }
+}

--- a/app/src/androidTest/java/com/privatehealthjournal/data/repository/LogRepositoryAtomicityTest.kt
+++ b/app/src/androidTest/java/com/privatehealthjournal/data/repository/LogRepositoryAtomicityTest.kt
@@ -1,0 +1,94 @@
+package com.privatehealthjournal.data.repository
+
+import androidx.room.Room
+import androidx.room.withTransaction
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.privatehealthjournal.data.AppDatabase
+import com.privatehealthjournal.data.entity.MedicationSet
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LogRepositoryAtomicityTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var repo: LogRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        repo = LogRepository(
+            db.mealDao(), db.symptomEntryDao(), db.bowelMovementDao(),
+            db.medicationDao(), db.otherEntryDao(), db.bloodPressureDao(),
+            db.cholesterolDao(), db.weightDao(), db.spO2Dao(),
+            db.bloodGlucoseDao(), db.medicationSetDao(),
+            db.medicationSetReminderDao(), db.medicationSetLogDao(),
+            db.cycleEntryDao(), db.stepCountDao(),
+            transaction = { block -> db.withTransaction { block() } }
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun logMedicationSetAtomically_commitsAllRows() = runTest {
+        val setId = db.medicationSetDao().insertSet(MedicationSet(name = "Evening"))
+        val timestamp = 1_700_000_000_000L
+
+        repo.logMedicationSetAtomically(
+            setId = setId,
+            items = listOf(
+                LogRepository.MedicationSetItemSpec("Atorvastatin", "20mg"),
+                LogRepository.MedicationSetItemSpec("Metformin", "500mg")
+            ),
+            timestamp = timestamp,
+            notes = "Logged from set: Evening"
+        )
+
+        val medications = repo.allMedications.first()
+        assertEquals(2, medications.size)
+        assertTrue(medications.all { it.timestamp == timestamp })
+        assertTrue(medications.all { it.notes == "Logged from set: Evening" })
+
+        val logs = repo.getAllMedicationSetLogs().first()
+        assertEquals(1, logs.size)
+        assertEquals(setId, logs[0].setId)
+        assertEquals(timestamp, logs[0].timestamp)
+    }
+
+    @Test
+    fun logMedicationSetAtomically_rollsBackOnFailure() = runTest {
+        // setId does not exist → MedicationSetLog insert violates the FK and rolls back the txn.
+        val invalidSetId = 99_999L
+
+        val threw = try {
+            repo.logMedicationSetAtomically(
+                setId = invalidSetId,
+                items = listOf(LogRepository.MedicationSetItemSpec("Atorvastatin", "20mg")),
+                timestamp = 1L,
+                notes = "should not commit"
+            )
+            false
+        } catch (e: Exception) {
+            true
+        }
+
+        assertTrue("FK violation should have surfaced", threw)
+        // Neither the MedicationEntry rows nor the MedicationSetLog row should have committed.
+        assertEquals(0, repo.allMedications.first().size)
+        assertEquals(0, repo.getAllMedicationSetLogs().first().size)
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/MainActivity.kt
+++ b/app/src/main/java/com/privatehealthjournal/MainActivity.kt
@@ -49,13 +49,15 @@ import com.privatehealthjournal.viewmodel.LogViewModel
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.lifecycleScope
 import androidx.room.withTransaction
 import com.privatehealthjournal.data.AppDatabase
 import com.privatehealthjournal.data.repository.LogRepository
+import com.privatehealthjournal.ui.nav.NavIntent
+import com.privatehealthjournal.ui.nav.route
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -127,44 +129,14 @@ class MainActivity : ComponentActivity() {
                         navController = navController,
                         startDestination = "home"
                     ) {
+                        val onNavigate: (NavIntent) -> Unit = { intent ->
+                            when (intent) {
+                                NavIntent.Back -> navController.popBackStack()
+                                else -> navController.navigate(intent.route())
+                            }
+                        }
                         composable("home") {
-                            HomeScreen(
-                                viewModel = viewModel,
-                                onAddMeal = { navController.navigate("add_meal") },
-                                onAddSymptom = { name ->
-                                    if (name != null) navController.navigate("add_symptom?name=$name")
-                                    else navController.navigate("add_symptom")
-                                },
-                                onAddOther = { otherType -> navController.navigate("add_other?type=$otherType") },
-                                onAddMedication = { name ->
-                                    if (name != null) navController.navigate("add_medication?name=$name")
-                                    else navController.navigate("add_medication")
-                                },
-                                onAddBloodPressure = { navController.navigate("add_blood_pressure") },
-                                onAddCholesterol = { navController.navigate("add_cholesterol") },
-                                onAddWeight = { navController.navigate("add_weight") },
-                                onAddSpO2 = { navController.navigate("add_spo2") },
-                                onAddBloodGlucose = { navController.navigate("add_blood_glucose") },
-                                onAddStepCount = { navController.navigate("add_step_count") },
-                                onViewBiometricsChart = { navController.navigate("biometrics_chart") },
-                                onViewHistory = { navController.navigate("history") },
-                                onViewCalendar = { navController.navigate("calendar") },
-                                onViewSettings = { navController.navigate("settings") },
-                                onEditMeal = { id -> navController.navigate("edit_meal/$id") },
-                                onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
-                                onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
-                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
-                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
-                                onEditWeight = { id -> navController.navigate("edit_weight/$id") },
-                                onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
-                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") },
-                                onViewMedicationSets = { navController.navigate("medication_sets") },
-                                onViewMealBudget = { navController.navigate("meal_budget") },
-                                onViewCycleTracking = { navController.navigate("cycle_tracking") },
-                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") }
-                            )
+                            HomeScreen(viewModel = viewModel, onNavigate = onNavigate)
                         }
                         composable(
                             route = "add_meal?mealType={mealType}",
@@ -276,38 +248,10 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                         composable("calendar") {
-                            CalendarScreen(
-                                viewModel = viewModel,
-                                onNavigateBack = { navController.popBackStack() },
-                                onEditMeal = { id -> navController.navigate("edit_meal/$id") },
-                                onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
-                                onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
-                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
-                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
-                                onEditWeight = { id -> navController.navigate("edit_weight/$id") },
-                                onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
-                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") },
-                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") }
-                            )
+                            CalendarScreen(viewModel = viewModel, onNavigate = onNavigate)
                         }
                         composable("history") {
-                            HistoryScreen(
-                                viewModel = viewModel,
-                                onNavigateBack = { navController.popBackStack() },
-                                onEditMeal = { id -> navController.navigate("edit_meal/$id") },
-                                onEditSymptom = { id -> navController.navigate("edit_symptom/$id") },
-                                onEditOther = { id -> navController.navigate("edit_other/$id") },
-                                onEditMedication = { id -> navController.navigate("edit_medication/$id") },
-                                onEditBloodPressure = { id -> navController.navigate("edit_blood_pressure/$id") },
-                                onEditCholesterol = { id -> navController.navigate("edit_cholesterol/$id") },
-                                onEditWeight = { id -> navController.navigate("edit_weight/$id") },
-                                onEditSpO2 = { id -> navController.navigate("edit_spo2/$id") },
-                                onEditBloodGlucose = { id -> navController.navigate("edit_blood_glucose/$id") },
-                                onEditCycleEntry = { id -> navController.navigate("edit_cycle_entry/$id") },
-                                onEditStepCount = { id -> navController.navigate("edit_step_count/$id") }
-                            )
+                            HistoryScreen(viewModel = viewModel, onNavigate = onNavigate)
                         }
                         composable("cycle_tracking") {
                             CycleTrackingScreen(

--- a/app/src/main/java/com/privatehealthjournal/ui/components/EditingEntry.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/EditingEntry.kt
@@ -1,0 +1,28 @@
+package com.privatehealthjournal.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Wires the two LaunchedEffects every Add/Edit screen needs: one that asks the
+ * ViewModel to load an entity for editing when [editId] is non-null, another that
+ * copies the loaded entity into the local form state via [onLoaded].
+ */
+@Composable
+fun <T : Any> rememberEditingEntry(
+    editId: Long?,
+    editingFlow: StateFlow<T?>,
+    load: suspend (Long) -> Unit,
+    onLoaded: (T) -> Unit
+) {
+    val editing by editingFlow.collectAsState()
+    LaunchedEffect(editId) {
+        if (editId != null) load(editId)
+    }
+    LaunchedEffect(editing) {
+        editing?.let(onLoaded)
+    }
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/components/EntryTopAppBar.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/EntryTopAppBar.kt
@@ -1,0 +1,39 @@
+package com.privatehealthjournal.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Centre-aligned top bar shared by every Add/Edit entry screen. Owns the title,
+ * back button, and container colour so individual screens only decide their title
+ * string and back-press behaviour. Container defaults to surfaceVariant; screens
+ * that want a different category accent (e.g. medication uses tertiaryContainer)
+ * can override [containerColor].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EntryTopAppBar(
+    title: String,
+    onBack: () -> Unit,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceVariant
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(title, fontWeight = FontWeight.Bold) },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = containerColor)
+    )
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/nav/NavIntent.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/nav/NavIntent.kt
@@ -1,0 +1,79 @@
+package com.privatehealthjournal.ui.nav
+
+/**
+ * One-shot navigation request a top-level screen hands to the host so the
+ * Composable signatures stay small. Each [NavIntent] is translated into a
+ * route string (or a back-pop) by [NavIntent.routeOrBack].
+ */
+sealed class NavIntent {
+    data object Back : NavIntent()
+
+    // Top-level destinations
+    data object History : NavIntent()
+    data object Calendar : NavIntent()
+    data object Settings : NavIntent()
+    data object MedicationSets : NavIntent()
+    data object MealBudget : NavIntent()
+    data object BiometricsChart : NavIntent()
+    data object CycleTracking : NavIntent()
+
+    // Add screens — some carry a prefill argument
+    data object AddMeal : NavIntent()
+    data class AddSymptom(val prefillName: String? = null) : NavIntent()
+    data class AddMedication(val prefillName: String? = null) : NavIntent()
+    data class AddOther(val type: String) : NavIntent()
+    data object AddBloodPressure : NavIntent()
+    data object AddCholesterol : NavIntent()
+    data object AddWeight : NavIntent()
+    data object AddSpO2 : NavIntent()
+    data object AddBloodGlucose : NavIntent()
+    data object AddStepCount : NavIntent()
+    data object AddCycleEntry : NavIntent()
+
+    // Edit screens — all carry an entity id
+    data class EditMeal(val id: Long) : NavIntent()
+    data class EditSymptom(val id: Long) : NavIntent()
+    data class EditOther(val id: Long) : NavIntent()
+    data class EditMedication(val id: Long) : NavIntent()
+    data class EditBloodPressure(val id: Long) : NavIntent()
+    data class EditCholesterol(val id: Long) : NavIntent()
+    data class EditWeight(val id: Long) : NavIntent()
+    data class EditSpO2(val id: Long) : NavIntent()
+    data class EditBloodGlucose(val id: Long) : NavIntent()
+    data class EditStepCount(val id: Long) : NavIntent()
+    data class EditCycleEntry(val id: Long) : NavIntent()
+}
+
+/** Maps a non-[NavIntent.Back] intent to its Navigation Compose route string. */
+fun NavIntent.route(): String = when (this) {
+    NavIntent.Back -> error("Back is not a route — handle separately via popBackStack().")
+    NavIntent.History -> "history"
+    NavIntent.Calendar -> "calendar"
+    NavIntent.Settings -> "settings"
+    NavIntent.MedicationSets -> "medication_sets"
+    NavIntent.MealBudget -> "meal_budget"
+    NavIntent.BiometricsChart -> "biometrics_chart"
+    NavIntent.CycleTracking -> "cycle_tracking"
+    NavIntent.AddMeal -> "add_meal"
+    is NavIntent.AddSymptom -> if (prefillName != null) "add_symptom?name=$prefillName" else "add_symptom"
+    is NavIntent.AddMedication -> if (prefillName != null) "add_medication?name=$prefillName" else "add_medication"
+    is NavIntent.AddOther -> "add_other?type=$type"
+    NavIntent.AddBloodPressure -> "add_blood_pressure"
+    NavIntent.AddCholesterol -> "add_cholesterol"
+    NavIntent.AddWeight -> "add_weight"
+    NavIntent.AddSpO2 -> "add_spo2"
+    NavIntent.AddBloodGlucose -> "add_blood_glucose"
+    NavIntent.AddStepCount -> "add_step_count"
+    NavIntent.AddCycleEntry -> "add_cycle_entry"
+    is NavIntent.EditMeal -> "edit_meal/$id"
+    is NavIntent.EditSymptom -> "edit_symptom/$id"
+    is NavIntent.EditOther -> "edit_other/$id"
+    is NavIntent.EditMedication -> "edit_medication/$id"
+    is NavIntent.EditBloodPressure -> "edit_blood_pressure/$id"
+    is NavIntent.EditCholesterol -> "edit_cholesterol/$id"
+    is NavIntent.EditWeight -> "edit_weight/$id"
+    is NavIntent.EditSpO2 -> "edit_spo2/$id"
+    is NavIntent.EditBloodGlucose -> "edit_blood_glucose/$id"
+    is NavIntent.EditStepCount -> "edit_step_count/$id"
+    is NavIntent.EditCycleEntry -> "edit_cycle_entry/$id"
+}

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
@@ -12,22 +12,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bloodtype
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +36,8 @@ import com.privatehealthjournal.data.entity.BloodGlucoseEntry
 import com.privatehealthjournal.data.entity.GlucoseMealContext
 import com.privatehealthjournal.data.entity.GlucoseUnit
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,7 +47,6 @@ fun AddBloodGlucoseScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingBloodGlucose.collectAsState()
     val isEditMode = editId != null
 
     var glucoseLevel by rememberSaveable { mutableStateOf("") }
@@ -61,53 +56,36 @@ fun AddBloodGlucoseScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadBloodGlucoseForEditing(editId)
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingBloodGlucose,
+        load = { viewModel.loadBloodGlucoseForEditing(it) }
+    ) { entry ->
+        glucoseLevel = if (entry.glucoseLevel == entry.glucoseLevel.toLong().toDouble()) {
+            entry.glucoseLevel.toLong().toString()
+        } else {
+            entry.glucoseLevel.toString()
         }
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            glucoseLevel = if (entry.glucoseLevel == entry.glucoseLevel.toLong().toDouble()) {
-                entry.glucoseLevel.toLong().toString()
-            } else {
-                entry.glucoseLevel.toString()
-            }
-            unit = entry.unit
-            mealContext = entry.mealContext
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+        unit = entry.unit
+        mealContext = entry.mealContext
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
     val glucoseValue = glucoseLevel.toDoubleOrNull()
     val isValid = glucoseValue != null && glucoseValue > 0
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Blood Glucose" else "Log Blood Glucose",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Blood Glucose" else "Log Blood Glucose",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
@@ -12,21 +12,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +33,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.BloodPressureEntry
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,7 +44,6 @@ fun AddBloodPressureScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingBloodPressure.collectAsState()
     val isEditMode = editId != null
 
     var systolic by rememberSaveable { mutableStateOf("") }
@@ -58,48 +53,31 @@ fun AddBloodPressureScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadBloodPressureForEditing(editId)
-        }
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            systolic = entry.systolic.toString()
-            diastolic = entry.diastolic.toString()
-            pulse = entry.pulse?.toString() ?: ""
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingBloodPressure,
+        load = { viewModel.loadBloodPressureForEditing(it) }
+    ) { entry ->
+        systolic = entry.systolic.toString()
+        diastolic = entry.diastolic.toString()
+        pulse = entry.pulse?.toString() ?: ""
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
     val isValid = systolic.toIntOrNull() != null && diastolic.toIntOrNull() != null
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Blood Pressure" else "Log Blood Pressure",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Blood Pressure" else "Log Blood Pressure",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
@@ -14,24 +14,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -47,6 +41,8 @@ import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.BowelMovementEntry
 import com.privatehealthjournal.data.entity.BristolType
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,7 +52,6 @@ fun AddBowelMovementScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingBowelMovement by viewModel.editingBowelMovement.collectAsState()
     val isEditMode = editId != null
 
     var selectedType by rememberSaveable { mutableIntStateOf(4) }
@@ -64,46 +59,28 @@ fun AddBowelMovementScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    // Load existing entry for editing
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadBowelMovementForEditing(editId)
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingBowelMovement,
+        load = { viewModel.loadBowelMovementForEditing(it) }
+    ) { entry ->
+        selectedType = entry.bristolType
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
-    // Populate fields when editing entry is loaded
-    LaunchedEffect(editingBowelMovement) {
-        editingBowelMovement?.let { entry ->
-            selectedType = entry.bristolType
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Bowel Movement" else "Log Bowel Movement",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Bowel Movement" else "Log Bowel Movement",
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
@@ -12,21 +12,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bloodtype
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +33,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.CholesterolEntry
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,7 +44,6 @@ fun AddCholesterolScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingCholesterol.collectAsState()
     val isEditMode = editId != null
 
     var total by rememberSaveable { mutableStateOf("") }
@@ -59,49 +54,32 @@ fun AddCholesterolScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadCholesterolForEditing(editId)
-        }
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            total = entry.total?.toString() ?: ""
-            ldl = entry.ldl?.toString() ?: ""
-            hdl = entry.hdl?.toString() ?: ""
-            triglycerides = entry.triglycerides?.toString() ?: ""
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingCholesterol,
+        load = { viewModel.loadCholesterolForEditing(it) }
+    ) { entry ->
+        total = entry.total?.toString() ?: ""
+        ldl = entry.ldl?.toString() ?: ""
+        hdl = entry.hdl?.toString() ?: ""
+        triglycerides = entry.triglycerides?.toString() ?: ""
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
     val hasAtLeastOneValue = total.isNotBlank() || ldl.isNotBlank() || hdl.isNotBlank() || triglycerides.isNotBlank()
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Cholesterol" else "Log Cholesterol",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Cholesterol" else "Log Cholesterol",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
@@ -12,23 +12,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,6 +37,8 @@ import com.privatehealthjournal.data.entity.CycleEntry
 import com.privatehealthjournal.data.entity.CycleSymptom
 import com.privatehealthjournal.data.entity.FlowIntensity
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 private val CycleRose = Color(0xFFE91E63)
@@ -54,7 +50,6 @@ fun AddCycleEntryScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingCycleEntry.collectAsState()
     val isEditMode = editId != null
 
     var selectedFlow by rememberSaveable { mutableStateOf(FlowIntensity.MEDIUM) }
@@ -63,42 +58,28 @@ fun AddCycleEntryScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadCycleEntryForEditing(editId)
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingCycleEntry,
+        load = { viewModel.loadCycleEntryForEditing(it) }
+    ) { entry ->
+        selectedFlow = entry.flow
+        selectedSymptoms = CycleSymptom.decode(entry.symptoms)
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            selectedFlow = entry.flow
-            selectedSymptoms = CycleSymptom.decode(entry.symptoms)
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Period Entry" else "Log Period",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Period Entry" else "Log Period",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMealScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cookie
 import androidx.compose.material.icons.filled.DinnerDining
@@ -24,7 +23,6 @@ import androidx.compose.material.icons.filled.BrunchDining
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -36,9 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -56,6 +52,8 @@ import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.MealEntry
 import com.privatehealthjournal.data.entity.MealType
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -66,7 +64,6 @@ fun AddMealScreen(
     editId: Long? = null,
     preselectedMealType: String? = null
 ) {
-    val editingMeal by viewModel.editingMeal.collectAsState()
     val isEditMode = editId != null
 
     val initialMealType = preselectedMealType?.let {
@@ -86,51 +83,33 @@ fun AddMealScreen(
     val existingTags by viewModel.allTags.collectAsState()
     val foodNames by viewModel.allFoodNames.collectAsState()
 
-    // Load existing entry for editing
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadMealForEditing(editId)
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingMeal,
+        load = { viewModel.loadMealForEditing(it) }
+    ) { mealWithDetails ->
+        selectedMealType = mealWithDetails.meal.mealType
+        foods.clear()
+        foods.addAll(mealWithDetails.foods.map { it.name })
+        tags.clear()
+        tags.addAll(mealWithDetails.tags.map { it.name })
+        notes = mealWithDetails.meal.notes
+        pointCostText = mealWithDetails.meal.pointCost?.toString() ?: ""
+        timestamp = mealWithDetails.meal.timestamp
+        existingId = mealWithDetails.meal.id
     }
 
-    // Populate fields when editing entry is loaded
-    LaunchedEffect(editingMeal) {
-        editingMeal?.let { mealWithDetails ->
-            selectedMealType = mealWithDetails.meal.mealType
-            foods.clear()
-            foods.addAll(mealWithDetails.foods.map { it.name })
-            tags.clear()
-            tags.addAll(mealWithDetails.tags.map { it.name })
-            notes = mealWithDetails.meal.notes
-            pointCostText = mealWithDetails.meal.pointCost?.toString() ?: ""
-            timestamp = mealWithDetails.meal.timestamp
-            existingId = mealWithDetails.meal.id
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Meal" else "Log Meal",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Meal" else "Log Meal",
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.primaryContainer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
@@ -12,23 +12,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -41,6 +36,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.MedicationEntry
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -51,7 +48,6 @@ fun AddMedicationScreen(
     editId: Long? = null,
     prefillName: String? = null
 ) {
-    val editingMedication by viewModel.editingMedication.collectAsState()
     val medicationNames by viewModel.allMedicationNames.collectAsState()
     val isEditMode = editId != null
 
@@ -61,47 +57,29 @@ fun AddMedicationScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    // Load existing entry for editing
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadMedicationForEditing(editId)
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingMedication,
+        load = { viewModel.loadMedicationForEditing(it) }
+    ) { entry ->
+        name = entry.name
+        dosage = entry.dosage
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
-    // Populate fields when editing entry is loaded
-    LaunchedEffect(editingMedication) {
-        editingMedication?.let { entry ->
-            name = entry.name
-            dosage = entry.dosage
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Medication" else "Log Medication",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Medication" else "Log Medication",
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
@@ -15,15 +15,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,9 +30,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -46,6 +42,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 private data class MedItemState(
@@ -60,7 +58,6 @@ fun AddMedicationSetScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingSet by viewModel.editingMedicationSet.collectAsState()
     val medicationNames by viewModel.allMedicationNames.collectAsState()
     val isEditMode = editId != null
 
@@ -68,49 +65,33 @@ fun AddMedicationSetScreen(
     val items = remember { mutableStateListOf(MedItemState()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadMedicationSetForEditing(editId)
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingMedicationSet,
+        load = { viewModel.loadMedicationSetForEditing(it) }
+    ) { setWithItems ->
+        setName = setWithItems.set.name
+        existingId = setWithItems.set.id
+        items.clear()
+        setWithItems.items.forEach { item ->
+            items.add(MedItemState(name = item.name, dosage = item.dosage))
+        }
+        if (items.isEmpty()) {
+            items.add(MedItemState())
         }
     }
 
-    LaunchedEffect(editingSet) {
-        editingSet?.let { setWithItems ->
-            setName = setWithItems.set.name
-            existingId = setWithItems.set.id
-            items.clear()
-            setWithItems.items.forEach { item ->
-                items.add(MedItemState(name = item.name, dosage = item.dosage))
-            }
-            if (items.isEmpty()) {
-                items.add(MedItemState())
-            }
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Medication Set" else "New Medication Set",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Medication Set" else "New Medication Set",
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
             )
         }
     ) { paddingValues ->
@@ -220,7 +201,7 @@ fun AddMedicationSetScreen(
                     }
 
                     if (index < items.lastIndex) {
-                        Divider(
+                        HorizontalDivider(
                             modifier = Modifier.padding(vertical = 12.dp),
                             color = MaterialTheme.colorScheme.outlineVariant
                         )

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -24,17 +23,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -54,6 +49,8 @@ import com.privatehealthjournal.data.entity.BristolType
 import com.privatehealthjournal.data.entity.OtherEntry
 import com.privatehealthjournal.data.entity.OtherEntryType
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -64,7 +61,6 @@ fun AddOtherEntryScreen(
     editId: Long? = null,
     preselectedType: String? = null
 ) {
-    val editingOtherEntry by viewModel.editingOtherEntry.collectAsState()
     val exerciseTypes by viewModel.exerciseTypes.collectAsState()
     val sleepQualities by viewModel.sleepQualities.collectAsState()
     val stressSources by viewModel.stressSources.collectAsState()
@@ -87,26 +83,20 @@ fun AddOtherEntryScreen(
     // For bowel movement Bristol scale
     var selectedBristolType by rememberSaveable { mutableIntStateOf(4) }
 
-    // Load existing entry for editing
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadOtherEntryForEditing(editId)
-        }
-    }
-
-    // Populate fields when editing entry is loaded
-    LaunchedEffect(editingOtherEntry) {
-        editingOtherEntry?.let { entry ->
-            selectedType = entry.entryType
-            subType = entry.subType
-            value = entry.value
-            notes = entry.notes
-            pointCreditText = entry.pointCredit?.toString() ?: ""
-            timestamp = entry.timestamp
-            existingId = entry.id
-            if (entry.entryType == OtherEntryType.BOWEL_MOVEMENT) {
-                selectedBristolType = entry.value.toIntOrNull() ?: 4
-            }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingOtherEntry,
+        load = { viewModel.loadOtherEntryForEditing(it) }
+    ) { entry ->
+        selectedType = entry.entryType
+        subType = entry.subType
+        value = entry.value
+        notes = entry.notes
+        pointCreditText = entry.pointCredit?.toString() ?: ""
+        timestamp = entry.timestamp
+        existingId = entry.id
+        if (entry.entryType == OtherEntryType.BOWEL_MOVEMENT) {
+            selectedBristolType = entry.value.toIntOrNull() ?: 4
         }
     }
 
@@ -116,29 +106,17 @@ fun AddOtherEntryScreen(
         "Log ${getTypeTitle(selectedType)}"
     }
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        screenTitle,
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
-                )
+            EntryTopAppBar(
+                title = screenTitle,
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
@@ -10,25 +10,18 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Air
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -37,6 +30,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.SpO2Entry
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -46,7 +41,6 @@ fun AddSpO2Screen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingSpO2.collectAsState()
     val isEditMode = editId != null
 
     var spo2 by rememberSaveable { mutableStateOf("") }
@@ -55,48 +49,31 @@ fun AddSpO2Screen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadSpO2ForEditing(editId)
-        }
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            spo2 = entry.spo2.toString()
-            pulse = entry.pulse?.toString() ?: ""
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingSpO2,
+        load = { viewModel.loadSpO2ForEditing(it) }
+    ) { entry ->
+        spo2 = entry.spo2.toString()
+        pulse = entry.pulse?.toString() ?: ""
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
     val spo2Value = spo2.toIntOrNull()
     val isValid = spo2Value != null && spo2Value in 0..100
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit SpO2" else "Log SpO2",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit SpO2" else "Log SpO2",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
@@ -13,24 +13,18 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.DirectionsWalk
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +39,8 @@ import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.StepCountEntry
 import com.privatehealthjournal.ui.components.DatePickerDialogWrapper
 import com.privatehealthjournal.ui.components.formatDate
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.time.Instant
 import java.time.LocalDate
@@ -57,7 +53,6 @@ fun AddStepCountScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingStepCount.collectAsState()
     val isEditMode = editId != null
 
     var steps by rememberSaveable { mutableStateOf("") }
@@ -68,43 +63,31 @@ fun AddStepCountScreen(
     var existingEntry by remember { mutableStateOf<StepCountEntry?>(null) }
     var showDatePicker by remember { mutableStateOf(false) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) viewModel.loadStepCountForEditing(editId)
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            steps = entry.steps.toString()
-            notes = entry.notes
-            val date = LocalDate.ofEpochDay(entry.dateEpochDay)
-            dateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-            existingEntry = entry
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingStepCount,
+        load = { viewModel.loadStepCountForEditing(it) }
+    ) { entry ->
+        steps = entry.steps.toString()
+        notes = entry.notes
+        val date = LocalDate.ofEpochDay(entry.dateEpochDay)
+        dateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        existingEntry = entry
     }
 
     val stepsValue = steps.toIntOrNull()
     val isValid = stepsValue != null && stepsValue >= 0
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Steps" else "Log Steps",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Steps" else "Log Steps",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
@@ -14,26 +14,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -48,6 +43,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.SymptomEntry
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 import kotlin.math.roundToInt
 
@@ -59,7 +56,6 @@ fun AddSymptomScreen(
     editId: Long? = null,
     prefillName: String? = null
 ) {
-    val editingSymptom by viewModel.editingSymptom.collectAsState()
     val symptomNames by viewModel.allSymptomNames.collectAsState()
     val isEditMode = editId != null
 
@@ -73,49 +69,31 @@ fun AddSymptomScreen(
     var hasEndTime by rememberSaveable { mutableStateOf(false) }
     var endTime by rememberSaveable { mutableLongStateOf(currentTime) }
 
-    // Load existing entry for editing
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadSymptomForEditing(editId)
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingSymptom,
+        load = { viewModel.loadSymptomForEditing(it) }
+    ) { entry ->
+        symptomName = entry.name
+        severity = entry.severity.toFloat()
+        notes = entry.notes
+        startTime = entry.startTime
+        hasEndTime = entry.endTime != null
+        endTime = entry.endTime ?: currentTime
+        existingId = entry.id
     }
 
-    // Populate fields when editing entry is loaded
-    LaunchedEffect(editingSymptom) {
-        editingSymptom?.let { entry ->
-            symptomName = entry.name
-            severity = entry.severity.toFloat()
-            notes = entry.notes
-            startTime = entry.startTime
-            hasEndTime = entry.endTime != null
-            endTime = entry.endTime ?: currentTime
-            existingId = entry.id
-        }
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
     }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Symptom" else "Log Symptom",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Symptom" else "Log Symptom",
+                onBack = handleBack,
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
@@ -13,23 +13,17 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MonitorWeight
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,6 +37,8 @@ import androidx.compose.ui.unit.dp
 import com.privatehealthjournal.data.entity.WeightEntry
 import com.privatehealthjournal.data.entity.WeightUnit
 import com.privatehealthjournal.ui.components.DateTimePicker
+import com.privatehealthjournal.ui.components.EntryTopAppBar
+import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -52,7 +48,6 @@ fun AddWeightScreen(
     onNavigateBack: () -> Unit,
     editId: Long? = null
 ) {
-    val editingEntry by viewModel.editingWeight.collectAsState()
     val isEditMode = editId != null
 
     var weight by rememberSaveable { mutableStateOf("") }
@@ -61,47 +56,30 @@ fun AddWeightScreen(
     var timestamp by rememberSaveable { mutableLongStateOf(System.currentTimeMillis()) }
     var existingId by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    LaunchedEffect(editId) {
-        if (editId != null) {
-            viewModel.loadWeightForEditing(editId)
-        }
-    }
-
-    LaunchedEffect(editingEntry) {
-        editingEntry?.let { entry ->
-            weight = entry.weight.toString()
-            unit = entry.unit
-            notes = entry.notes
-            timestamp = entry.timestamp
-            existingId = entry.id
-        }
+    rememberEditingEntry(
+        editId = editId,
+        editingFlow = viewModel.editingWeight,
+        load = { viewModel.loadWeightForEditing(it) }
+    ) { entry ->
+        weight = entry.weight.toString()
+        unit = entry.unit
+        notes = entry.notes
+        timestamp = entry.timestamp
+        existingId = entry.id
     }
 
     val isValid = weight.toDoubleOrNull() != null && weight.toDoubleOrNull()!! > 0
 
+    val handleBack = {
+        viewModel.clearEditingState()
+        onNavigateBack()
+    }
+
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        if (isEditMode) "Edit Weight" else "Log Weight",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        viewModel.clearEditingState()
-                        onNavigateBack()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
+            EntryTopAppBar(
+                title = if (isEditMode) "Edit Weight" else "Log Weight",
+                onBack = handleBack
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/BiometricsChartScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/BiometricsChartScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -134,7 +134,7 @@ fun BiometricsChartScreen(
                 .padding(paddingValues)
         ) {
             // Tab Row
-            ScrollableTabRow(
+            PrimaryScrollableTabRow(
                 selectedTabIndex = selectedTab,
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -63,6 +63,7 @@ import com.privatehealthjournal.ui.components.SpO2Card
 import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
+import com.privatehealthjournal.ui.nav.NavIntent
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.time.DayOfWeek
 import java.time.Instant
@@ -76,19 +77,9 @@ import java.util.Locale
 @Composable
 fun CalendarScreen(
     viewModel: LogViewModel,
-    onNavigateBack: () -> Unit,
-    onEditMeal: (Long) -> Unit = {},
-    onEditSymptom: (Long) -> Unit = {},
-    onEditOther: (Long) -> Unit = {},
-    onEditMedication: (Long) -> Unit = {},
-    onEditBloodPressure: (Long) -> Unit = {},
-    onEditCholesterol: (Long) -> Unit = {},
-    onEditWeight: (Long) -> Unit = {},
-    onEditSpO2: (Long) -> Unit = {},
-    onEditBloodGlucose: (Long) -> Unit = {},
-    onEditCycleEntry: (Long) -> Unit = {},
-    onEditStepCount: (Long) -> Unit = {}
+    onNavigate: (NavIntent) -> Unit
 ) {
+    val onNavigateBack = { onNavigate(NavIntent.Back) }
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
     val allMedications by viewModel.allMedications.collectAsState()
@@ -199,12 +190,12 @@ fun CalendarScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )
@@ -269,7 +260,7 @@ fun CalendarScreen(
                             is CalendarEntry.Meal -> MealEntryCard(
                                 meal = entry.entry,
                                 onDelete = { viewModel.deleteMeal(entry.entry) },
-                                onEdit = { onEditMeal(entry.entry.meal.id) }
+                                onEdit = { onNavigate(NavIntent.EditMeal(entry.entry.meal.id)) }
                             )
                             is CalendarEntry.Symptom -> SymptomEntryCard(
                                 name = entry.entry.name,
@@ -278,52 +269,52 @@ fun CalendarScreen(
                                 startTime = entry.entry.startTime,
                                 endTime = entry.entry.endTime,
                                 onDelete = { viewModel.deleteSymptom(entry.entry) },
-                                onEdit = { onEditSymptom(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditSymptom(entry.entry.id)) }
                             )
                             is CalendarEntry.Medication -> MedicationCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteMedication(entry.entry) },
-                                onEdit = { onEditMedication(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditMedication(entry.entry.id)) }
                             )
                             is CalendarEntry.Other -> OtherEntryCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteOtherEntry(entry.entry) },
-                                onEdit = { onEditOther(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditOther(entry.entry.id)) }
                             )
                             is CalendarEntry.BloodPressure -> BloodPressureCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteBloodPressure(entry.entry) },
-                                onEdit = { onEditBloodPressure(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditBloodPressure(entry.entry.id)) }
                             )
                             is CalendarEntry.Cholesterol -> CholesterolCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteCholesterol(entry.entry) },
-                                onEdit = { onEditCholesterol(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditCholesterol(entry.entry.id)) }
                             )
                             is CalendarEntry.Weight -> WeightCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteWeight(entry.entry) },
-                                onEdit = { onEditWeight(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditWeight(entry.entry.id)) }
                             )
                             is CalendarEntry.SpO2 -> SpO2Card(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteSpO2(entry.entry) },
-                                onEdit = { onEditSpO2(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditSpO2(entry.entry.id)) }
                             )
                             is CalendarEntry.BloodGlucose -> BloodGlucoseCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteBloodGlucose(entry.entry) },
-                                onEdit = { onEditBloodGlucose(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditBloodGlucose(entry.entry.id)) }
                             )
                             is CalendarEntry.Cycle -> CycleEntryCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteCycleEntry(entry.entry) },
-                                onEdit = { onEditCycleEntry(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditCycleEntry(entry.entry.id)) }
                             )
                             is CalendarEntry.StepCount -> StepCountCard(
                                 entry = entry.entry,
                                 onDelete = { viewModel.deleteStepCount(entry.entry) },
-                                onEdit = { onEditStepCount(entry.entry.id) }
+                                onEdit = { onNavigate(NavIntent.EditStepCount(entry.entry.id)) }
                             )
                         }
                     }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -132,10 +132,10 @@ fun CycleTrackingScreen(
                 title = { Text("Cycle Tracking", fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HistoryScreen.kt
@@ -10,9 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -54,6 +54,7 @@ import com.privatehealthjournal.ui.components.SpO2Card
 import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
+import com.privatehealthjournal.ui.nav.NavIntent
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.time.Instant
 import java.time.LocalDate
@@ -68,19 +69,9 @@ enum class FilterType {
 @Composable
 fun HistoryScreen(
     viewModel: LogViewModel,
-    onNavigateBack: () -> Unit,
-    onEditMeal: (Long) -> Unit = {},
-    onEditSymptom: (Long) -> Unit = {},
-    onEditOther: (Long) -> Unit = {},
-    onEditMedication: (Long) -> Unit = {},
-    onEditBloodPressure: (Long) -> Unit = {},
-    onEditCholesterol: (Long) -> Unit = {},
-    onEditWeight: (Long) -> Unit = {},
-    onEditSpO2: (Long) -> Unit = {},
-    onEditBloodGlucose: (Long) -> Unit = {},
-    onEditCycleEntry: (Long) -> Unit = {},
-    onEditStepCount: (Long) -> Unit = {}
+    onNavigate: (NavIntent) -> Unit
 ) {
+    val onNavigateBack = { onNavigate(NavIntent.Back) }
     val allMeals by viewModel.allMeals.collectAsState()
     val allSymptoms by viewModel.allSymptomEntries.collectAsState()
     val allMedications by viewModel.allMedications.collectAsState()
@@ -108,12 +99,12 @@ fun HistoryScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )
@@ -255,7 +246,7 @@ fun HistoryScreen(
                                     .padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Divider(
+                                HorizontalDivider(
                                     modifier = Modifier.weight(1f),
                                     color = MaterialTheme.colorScheme.outlineVariant
                                 )
@@ -265,7 +256,7 @@ fun HistoryScreen(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier.padding(horizontal = 12.dp)
                                 )
-                                Divider(
+                                HorizontalDivider(
                                     modifier = Modifier.weight(1f),
                                     color = MaterialTheme.colorScheme.outlineVariant
                                 )
@@ -279,7 +270,7 @@ fun HistoryScreen(
                                 is HistoryEntry.Meal -> MealEntryCard(
                                     meal = entry.entry,
                                     onDelete = { viewModel.deleteMeal(entry.entry) },
-                                    onEdit = { onEditMeal(entry.entry.meal.id) }
+                                    onEdit = { onNavigate(NavIntent.EditMeal(entry.entry.meal.id)) }
                                 )
                                 is HistoryEntry.Symptom -> SymptomEntryCard(
                                     name = entry.entry.name,
@@ -288,52 +279,52 @@ fun HistoryScreen(
                                     startTime = entry.entry.startTime,
                                     endTime = entry.entry.endTime,
                                     onDelete = { viewModel.deleteSymptom(entry.entry) },
-                                    onEdit = { onEditSymptom(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditSymptom(entry.entry.id)) }
                                 )
                                 is HistoryEntry.Other -> OtherEntryCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteOtherEntry(entry.entry) },
-                                    onEdit = { onEditOther(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditOther(entry.entry.id)) }
                                 )
                                 is HistoryEntry.Medication -> MedicationCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteMedication(entry.entry) },
-                                    onEdit = { onEditMedication(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditMedication(entry.entry.id)) }
                                 )
                                 is HistoryEntry.BloodPressure -> BloodPressureCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteBloodPressure(entry.entry) },
-                                    onEdit = { onEditBloodPressure(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditBloodPressure(entry.entry.id)) }
                                 )
                                 is HistoryEntry.Cholesterol -> CholesterolCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteCholesterol(entry.entry) },
-                                    onEdit = { onEditCholesterol(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditCholesterol(entry.entry.id)) }
                                 )
                                 is HistoryEntry.Weight -> WeightCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteWeight(entry.entry) },
-                                    onEdit = { onEditWeight(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditWeight(entry.entry.id)) }
                                 )
                                 is HistoryEntry.SpO2 -> SpO2Card(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteSpO2(entry.entry) },
-                                    onEdit = { onEditSpO2(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditSpO2(entry.entry.id)) }
                                 )
                                 is HistoryEntry.BloodGlucose -> BloodGlucoseCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteBloodGlucose(entry.entry) },
-                                    onEdit = { onEditBloodGlucose(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditBloodGlucose(entry.entry.id)) }
                                 )
                                 is HistoryEntry.Cycle -> CycleEntryCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteCycleEntry(entry.entry) },
-                                    onEdit = { onEditCycleEntry(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditCycleEntry(entry.entry.id)) }
                                 )
                                 is HistoryEntry.StepCount -> StepCountCard(
                                     entry = entry.entry,
                                     onDelete = { viewModel.deleteStepCount(entry.entry) },
-                                    onEdit = { onEditStepCount(entry.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditStepCount(entry.entry.id)) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -76,6 +76,7 @@ import com.privatehealthjournal.ui.components.SpO2Card
 import com.privatehealthjournal.ui.components.StepCountCard
 import com.privatehealthjournal.ui.components.SymptomEntryCard
 import com.privatehealthjournal.ui.components.WeightCard
+import com.privatehealthjournal.ui.nav.NavIntent
 import com.privatehealthjournal.viewmodel.LogViewModel
 import java.time.Instant
 import java.time.LocalDate
@@ -86,34 +87,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun HomeScreen(
     viewModel: LogViewModel,
-    onAddMeal: () -> Unit,
-    onAddSymptom: (String?) -> Unit,
-    onAddOther: (String) -> Unit,
-    onAddMedication: (String?) -> Unit,
-    onAddBloodPressure: () -> Unit,
-    onAddCholesterol: () -> Unit,
-    onAddWeight: () -> Unit,
-    onAddSpO2: () -> Unit,
-    onAddBloodGlucose: () -> Unit,
-    onAddStepCount: () -> Unit = {},
-    onViewBiometricsChart: () -> Unit = {},
-    onViewHistory: () -> Unit,
-    onViewCalendar: () -> Unit = {},
-    onViewSettings: () -> Unit = {},
-    onEditMeal: (Long) -> Unit = {},
-    onEditSymptom: (Long) -> Unit = {},
-    onEditOther: (Long) -> Unit = {},
-    onEditMedication: (Long) -> Unit = {},
-    onEditBloodPressure: (Long) -> Unit = {},
-    onEditCholesterol: (Long) -> Unit = {},
-    onEditWeight: (Long) -> Unit = {},
-    onEditSpO2: (Long) -> Unit = {},
-    onEditBloodGlucose: (Long) -> Unit = {},
-    onEditStepCount: (Long) -> Unit = {},
-    onViewMedicationSets: () -> Unit = {},
-    onViewMealBudget: () -> Unit = {},
-    onViewCycleTracking: () -> Unit = {},
-    onEditCycleEntry: (Long) -> Unit = {}
+    onNavigate: (NavIntent) -> Unit
 ) {
     val recentMeals by viewModel.recentMeals.collectAsState()
     val recentSymptoms by viewModel.recentSymptomEntries.collectAsState()
@@ -143,25 +117,25 @@ fun HomeScreen(
                     )
                 },
                 actions = {
-                    IconButton(onClick = onViewMealBudget) {
+                    IconButton(onClick = { onNavigate(NavIntent.MealBudget) }) {
                         Icon(
                             imageVector = Icons.Default.Savings,
                             contentDescription = "Meal Budget"
                         )
                     }
-                    IconButton(onClick = onViewCalendar) {
+                    IconButton(onClick = { onNavigate(NavIntent.Calendar) }) {
                         Icon(
                             imageVector = Icons.Default.CalendarMonth,
                             contentDescription = "Calendar"
                         )
                     }
-                    IconButton(onClick = onViewHistory) {
+                    IconButton(onClick = { onNavigate(NavIntent.History) }) {
                         Icon(
                             imageVector = Icons.Default.History,
                             contentDescription = "History"
                         )
                     }
-                    IconButton(onClick = onViewSettings) {
+                    IconButton(onClick = { onNavigate(NavIntent.Settings) }) {
                         Icon(
                             imageVector = Icons.Default.Settings,
                             contentDescription = "Settings"
@@ -188,7 +162,7 @@ fun HomeScreen(
             ) {
                 // Meal button
                 Button(
-                    onClick = { onAddMeal() },
+                    onClick = { onNavigate(NavIntent.AddMeal) },
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary
                     )
@@ -204,7 +178,7 @@ fun HomeScreen(
 
                 // Symptom button
                 Button(
-                    onClick = { onAddSymptom(null) },
+                    onClick = { onNavigate(NavIntent.AddSymptom()) },
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.secondary
                     )
@@ -247,14 +221,14 @@ fun HomeScreen(
                             text = { Text("Log Medication") },
                             onClick = {
                                 medsMenuExpanded = false
-                                onAddMedication(null)
+                                onNavigate(NavIntent.AddMedication())
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Medication Sets") },
                             onClick = {
                                 medsMenuExpanded = false
-                                onViewMedicationSets()
+                                onNavigate(NavIntent.MedicationSets)
                             }
                         )
                     }
@@ -289,35 +263,35 @@ fun HomeScreen(
                             text = { Text("Blood Pressure") },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onAddBloodPressure()
+                                onNavigate(NavIntent.AddBloodPressure)
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Cholesterol") },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onAddCholesterol()
+                                onNavigate(NavIntent.AddCholesterol)
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Weight") },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onAddWeight()
+                                onNavigate(NavIntent.AddWeight)
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("SpO2 (Blood Oxygen)") },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onAddSpO2()
+                                onNavigate(NavIntent.AddSpO2)
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Blood Glucose") },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onAddBloodGlucose()
+                                onNavigate(NavIntent.AddBloodGlucose)
                             }
                         )
                         if (showStepCounting) {
@@ -325,11 +299,11 @@ fun HomeScreen(
                                 text = { Text("Steps") },
                                 onClick = {
                                     biometricsMenuExpanded = false
-                                    onAddStepCount()
+                                    onNavigate(NavIntent.AddStepCount)
                                 }
                             )
                         }
-                        Divider()
+                        HorizontalDivider()
                         DropdownMenuItem(
                             text = { Text("View Charts") },
                             leadingIcon = {
@@ -340,7 +314,7 @@ fun HomeScreen(
                             },
                             onClick = {
                                 biometricsMenuExpanded = false
-                                onViewBiometricsChart()
+                                onNavigate(NavIntent.BiometricsChart)
                             }
                         )
                     }
@@ -375,49 +349,49 @@ fun HomeScreen(
                             text = { Text("Bowel Movement") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("BOWEL_MOVEMENT")
+                                onNavigate(NavIntent.AddOther("BOWEL_MOVEMENT"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Sleep") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("SLEEP")
+                                onNavigate(NavIntent.AddOther("SLEEP"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Exercise") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("EXERCISE")
+                                onNavigate(NavIntent.AddOther("EXERCISE"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Stress") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("STRESS")
+                                onNavigate(NavIntent.AddOther("STRESS"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Mood") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("MOOD")
+                                onNavigate(NavIntent.AddOther("MOOD"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Water Intake") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("WATER_INTAKE")
+                                onNavigate(NavIntent.AddOther("WATER_INTAKE"))
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("Other") },
                             onClick = {
                                 otherMenuExpanded = false
-                                onAddOther("OTHER")
+                                onNavigate(NavIntent.AddOther("OTHER"))
                             }
                         )
                     }
@@ -426,7 +400,7 @@ fun HomeScreen(
                 // Cycle tracking button (hidden when showCycleTracking is false)
                 if (showCycleTracking) {
                     Button(
-                        onClick = { onViewCycleTracking() },
+                        onClick = { onNavigate(NavIntent.CycleTracking) },
                         colors = ButtonDefaults.buttonColors(
                             containerColor = Color(0xFFE91E63)
                         )
@@ -533,7 +507,7 @@ fun HomeScreen(
                                     .padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Divider(
+                                HorizontalDivider(
                                     modifier = Modifier.weight(1f),
                                     color = MaterialTheme.colorScheme.outlineVariant
                                 )
@@ -543,7 +517,7 @@ fun HomeScreen(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier.padding(horizontal = 12.dp)
                                 )
-                                Divider(
+                                HorizontalDivider(
                                     modifier = Modifier.weight(1f),
                                     color = MaterialTheme.colorScheme.outlineVariant
                                 )
@@ -557,7 +531,7 @@ fun HomeScreen(
                                 is EntryItem.Meal -> MealEntryCard(
                                     meal = item.entry,
                                     onDelete = { viewModel.deleteMeal(item.entry) },
-                                    onEdit = { onEditMeal(item.entry.meal.id) }
+                                    onEdit = { onNavigate(NavIntent.EditMeal(item.entry.meal.id)) }
                                 )
                                 is EntryItem.Symptom -> SymptomEntryCard(
                                     name = item.entry.name,
@@ -566,52 +540,52 @@ fun HomeScreen(
                                     startTime = item.entry.startTime,
                                     endTime = item.entry.endTime,
                                     onDelete = { viewModel.deleteSymptom(item.entry) },
-                                    onEdit = { onEditSymptom(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditSymptom(item.entry.id)) }
                                 )
                                 is EntryItem.Other -> OtherEntryCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteOtherEntry(item.entry) },
-                                    onEdit = { onEditOther(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditOther(item.entry.id)) }
                                 )
                                 is EntryItem.Medication -> MedicationCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteMedication(item.entry) },
-                                    onEdit = { onEditMedication(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditMedication(item.entry.id)) }
                                 )
                                 is EntryItem.BloodPressure -> BloodPressureCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteBloodPressure(item.entry) },
-                                    onEdit = { onEditBloodPressure(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditBloodPressure(item.entry.id)) }
                                 )
                                 is EntryItem.Cholesterol -> CholesterolCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteCholesterol(item.entry) },
-                                    onEdit = { onEditCholesterol(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditCholesterol(item.entry.id)) }
                                 )
                                 is EntryItem.Weight -> WeightCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteWeight(item.entry) },
-                                    onEdit = { onEditWeight(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditWeight(item.entry.id)) }
                                 )
                                 is EntryItem.SpO2 -> SpO2Card(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteSpO2(item.entry) },
-                                    onEdit = { onEditSpO2(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditSpO2(item.entry.id)) }
                                 )
                                 is EntryItem.BloodGlucose -> BloodGlucoseCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteBloodGlucose(item.entry) },
-                                    onEdit = { onEditBloodGlucose(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditBloodGlucose(item.entry.id)) }
                                 )
                                 is EntryItem.Cycle -> CycleEntryCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteCycleEntry(item.entry) },
-                                    onEdit = { onEditCycleEntry(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditCycleEntry(item.entry.id)) }
                                 )
                                 is EntryItem.StepCount -> StepCountCard(
                                     entry = item.entry,
                                     onDelete = { viewModel.deleteStepCount(item.entry) },
-                                    onEdit = { onEditStepCount(item.entry.id) }
+                                    onEdit = { onNavigate(NavIntent.EditStepCount(item.entry.id)) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DirectionsRun
@@ -25,7 +25,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -137,7 +137,7 @@ fun MealBudgetScreen(
                 title = { Text("Meal Budget", fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 actions = {
@@ -145,7 +145,7 @@ fun MealBudgetScreen(
                         Icon(Icons.Default.Settings, contentDescription = "Settings")
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )
@@ -477,7 +477,7 @@ private fun DayRow(
 
             // Expanded items
             if (isExpanded) {
-                Divider(
+                HorizontalDivider(
                     modifier = Modifier.padding(horizontal = 12.dp),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
                 )

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Alarm
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Medication
@@ -25,7 +25,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -82,12 +82,12 @@ fun MedicationSetsScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer
                 )
             )
@@ -251,7 +251,7 @@ private fun MedicationSetCard(
             // Reminders section
             if (reminders.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(8.dp))
-                Divider(color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.2f))
+                HorizontalDivider(color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.2f))
                 Spacer(modifier = Modifier.height(8.dp))
 
                 reminders.forEach { reminder ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/SettingsScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material3.Button
@@ -137,12 +137,12 @@ fun SettingsScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )

--- a/app/src/test/java/com/privatehealthjournal/ui/nav/NavIntentTest.kt
+++ b/app/src/test/java/com/privatehealthjournal/ui/nav/NavIntentTest.kt
@@ -1,0 +1,47 @@
+package com.privatehealthjournal.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class NavIntentTest {
+
+    @Test
+    fun topLevel_routes() {
+        assertEquals("history", NavIntent.History.route())
+        assertEquals("calendar", NavIntent.Calendar.route())
+        assertEquals("settings", NavIntent.Settings.route())
+        assertEquals("medication_sets", NavIntent.MedicationSets.route())
+        assertEquals("meal_budget", NavIntent.MealBudget.route())
+        assertEquals("biometrics_chart", NavIntent.BiometricsChart.route())
+        assertEquals("cycle_tracking", NavIntent.CycleTracking.route())
+    }
+
+    @Test
+    fun addScreens_withoutPrefill_produceBaseRoute() {
+        assertEquals("add_meal", NavIntent.AddMeal.route())
+        assertEquals("add_symptom", NavIntent.AddSymptom().route())
+        assertEquals("add_medication", NavIntent.AddMedication().route())
+        assertEquals("add_blood_pressure", NavIntent.AddBloodPressure.route())
+    }
+
+    @Test
+    fun addScreens_withPrefill_embedQueryArg() {
+        assertEquals("add_symptom?name=Headache", NavIntent.AddSymptom("Headache").route())
+        assertEquals("add_medication?name=Aspirin", NavIntent.AddMedication("Aspirin").route())
+        assertEquals("add_other?type=SLEEP", NavIntent.AddOther("SLEEP").route())
+    }
+
+    @Test
+    fun editScreens_embedId() {
+        assertEquals("edit_meal/42", NavIntent.EditMeal(42).route())
+        assertEquals("edit_symptom/7", NavIntent.EditSymptom(7).route())
+        assertEquals("edit_step_count/1", NavIntent.EditStepCount(1).route())
+        assertEquals("edit_cycle_entry/99", NavIntent.EditCycleEntry(99).route())
+    }
+
+    @Test
+    fun back_isNotARoute() {
+        assertThrows(IllegalStateException::class.java) { NavIntent.Back.route() }
+    }
+}


### PR DESCRIPTION
- New ui/components/EntryTopAppBar + ui/components/rememberEditingEntry helpers. All 13 Add*Screen.kt files adopt them, dropping the duplicated Scaffold CenterAlignedTopAppBar / back IconButton / two-LaunchedEffect pattern. Net ~370 LOC reduction.
- New ui/nav/NavIntent sealed class + route() extension. HomeScreen shrinks from 30 nav lambda params to one `onNavigate(NavIntent)`; HistoryScreen and CalendarScreen do the same. MainActivity's NavHost routes a single lambda instead of 30+ inline navigate() builders. NavIntent supports prefill (AddSymptom, AddMedication, AddOther) and id-bearing edit variants.
- Compose / M3 deprecation cleanup:
  * Icons.Filled.ArrowBack and Icons.Filled.ShowChart → AutoMirrored
  * Divider → HorizontalDivider
  * centerAlignedTopAppBarColors → topAppBarColors
  * ScrollableTabRow → PrimaryScrollableTabRow (BiometricsChartScreen)
  * LocalLifecycleOwner import moved to androidx.lifecycle.compose
- Test backfill:
  * Add androidx.room:room-testing + androidx.test:runner + kotlinx-coroutines-test to androidTest.
  * MedicationSetDaoTest: insertSetWithItems atomicity, update replaces items, deleteSet cascades to medication_set_items via FK.
  * MealDaoTest: insertMealWithDetails persists meal+foods+tags in one transaction; tag rows are reused across meals (no duplicate Tag).
  * LogRepositoryAtomicityTest: logMedicationSetAtomically commits all rows on success and rolls back fully on FK violation (no orphan MedicationEntry rows when the set-log insert fails).
  * NavIntentTest: pure JVM test for the route() mapping including prefill query args, id substitution, and Back-rejection.
- Reviewer's low-severity a11y audit found no actual missing contentDescription in the named screens; no code change there.