### PR TITLE
feat: brand color palette, disable Material You

### DIFF
--- a/app/src/main/java/com/privatehealthjournal/ui/components/BloodGlucoseCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/BloodGlucoseCard.kt
@@ -52,7 +52,7 @@ fun BloodGlucoseCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -64,7 +64,7 @@ fun BloodGlucoseCard(
             Icon(
                 imageVector = Icons.Default.Bloodtype,
                 contentDescription = "Blood Glucose",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor(),
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -85,7 +85,7 @@ fun BloodGlucoseCard(
                     Text(
                         text = context.displayLabel,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                     )
                 }
                 if (entry.notes.isNotBlank()) {
@@ -93,14 +93,14 @@ fun BloodGlucoseCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -109,7 +109,7 @@ fun BloodGlucoseCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -117,7 +117,7 @@ fun BloodGlucoseCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }
@@ -137,13 +137,13 @@ private fun formatGlucoseLevel(level: Double, unit: GlucoseUnit): String {
 private fun getGlucoseColor(level: Double, unit: GlucoseUnit) = when (unit) {
     GlucoseUnit.MG_DL -> when {
         level < 70 -> MaterialTheme.colorScheme.error
-        level <= 99 -> MaterialTheme.colorScheme.primary
+        level <= 99 -> com.privatehealthjournal.ui.theme.onBiometricContainerColor()
         level <= 125 -> MaterialTheme.colorScheme.tertiary
         else -> MaterialTheme.colorScheme.error
     }
     GlucoseUnit.MMOL_L -> when {
         level < 3.9 -> MaterialTheme.colorScheme.error
-        level <= 5.5 -> MaterialTheme.colorScheme.primary
+        level <= 5.5 -> com.privatehealthjournal.ui.theme.onBiometricContainerColor()
         level <= 6.9 -> MaterialTheme.colorScheme.tertiary
         else -> MaterialTheme.colorScheme.error
     }

--- a/app/src/main/java/com/privatehealthjournal/ui/components/BloodPressureCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/BloodPressureCard.kt
@@ -51,7 +51,7 @@ fun BloodPressureCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -84,7 +84,7 @@ fun BloodPressureCard(
                     Text(
                         text = "Pulse: $pulse bpm",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                     )
                 }
                 if (entry.notes.isNotBlank()) {
@@ -92,14 +92,14 @@ fun BloodPressureCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -108,7 +108,7 @@ fun BloodPressureCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -116,7 +116,7 @@ fun BloodPressureCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }
@@ -130,7 +130,7 @@ private fun getBloodPressureColor(systolic: Int, diastolic: Int) = when {
     systolic >= 140 || diastolic >= 90 -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
     systolic >= 130 || diastolic >= 80 -> MaterialTheme.colorScheme.tertiary
     systolic >= 120 -> MaterialTheme.colorScheme.secondary
-    else -> MaterialTheme.colorScheme.primary
+    else -> com.privatehealthjournal.ui.theme.onBiometricContainerColor()
 }
 
 private fun formatTimestamp(timestamp: Long): String {

--- a/app/src/main/java/com/privatehealthjournal/ui/components/CholesterolCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/CholesterolCard.kt
@@ -51,7 +51,7 @@ fun CholesterolCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -86,13 +86,13 @@ fun CholesterolCard(
                     Text(
                         text = values.joinToString(" | "),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                     )
                 } else {
                     Text(
                         text = "No values recorded",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
 
@@ -101,14 +101,14 @@ fun CholesterolCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -117,7 +117,7 @@ fun CholesterolCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -125,7 +125,7 @@ fun CholesterolCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/components/CycleEntryCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/CycleEntryCard.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -38,7 +38,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-private val CycleRose = Color(0xFFE91E63)
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -61,7 +60,7 @@ fun CycleEntryCard(
 
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        colors = CardDefaults.cardColors(containerColor = com.privatehealthjournal.ui.theme.cycleContainerColor())
     ) {
         Row(
             modifier = Modifier
@@ -70,9 +69,9 @@ fun CycleEntryCard(
             verticalAlignment = Alignment.Top
         ) {
             Icon(
-                imageVector = Icons.Default.Favorite,
+                imageVector = Icons.Default.WaterDrop,
                 contentDescription = "Cycle",
-                tint = CycleRose,
+                tint = com.privatehealthjournal.ui.theme.cycleAccentColor(),
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -87,7 +86,7 @@ fun CycleEntryCard(
                     text = entry.flow.displayLabel,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium,
-                    color = CycleRose
+                    color = com.privatehealthjournal.ui.theme.onCycleContainerColor()
                 )
                 if (symptoms.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(6.dp))
@@ -97,7 +96,7 @@ fun CycleEntryCard(
                                 onClick = {},
                                 label = { Text(symptom.displayLabel, style = MaterialTheme.typography.labelSmall) },
                                 colors = SuggestionChipDefaults.suggestionChipColors(
-                                    containerColor = CycleRose.copy(alpha = 0.12f)
+                                    containerColor = com.privatehealthjournal.ui.theme.cycleAccentColor().copy(alpha = 0.2f)
                                 )
                             )
                         }
@@ -108,14 +107,14 @@ fun CycleEntryCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onCycleContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatCycleTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onCycleContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -124,7 +123,7 @@ fun CycleEntryCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onCycleContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -132,7 +131,7 @@ fun CycleEntryCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onCycleContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/components/EntryCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/EntryCard.kt
@@ -190,7 +190,7 @@ fun SymptomEntryCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
         )
     ) {
         Row(
@@ -202,7 +202,7 @@ fun SymptomEntryCard(
             Icon(
                 imageVector = Icons.Default.Warning,
                 contentDescription = "Symptom",
-                tint = MaterialTheme.colorScheme.secondary,
+                tint = MaterialTheme.colorScheme.tertiary,
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -226,14 +226,14 @@ fun SymptomEntryCard(
                     Text(
                         text = notes,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
+                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimeRange(startTime, endTime),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.5f)
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -242,7 +242,7 @@ fun SymptomEntryCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
+                            tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -250,7 +250,7 @@ fun SymptomEntryCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
                     )
                 }
             }
@@ -431,7 +431,7 @@ fun OtherEntryCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+            containerColor = com.privatehealthjournal.ui.theme.otherContainerColor()
         )
     ) {
         Row(
@@ -457,7 +457,7 @@ fun OtherEntryCard(
                 Icon(
                     imageVector = icon,
                     contentDescription = title,
-                    tint = MaterialTheme.colorScheme.tertiary,
+                    tint = com.privatehealthjournal.ui.theme.otherAccentColor(),
                     modifier = Modifier.size(32.dp)
                 )
             }
@@ -482,7 +482,7 @@ fun OtherEntryCard(
                     Text(
                         text = subtitle,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onOtherContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 if (entry.notes.isNotBlank()) {
@@ -490,14 +490,14 @@ fun OtherEntryCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onOtherContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onOtherContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -506,7 +506,7 @@ fun OtherEntryCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onOtherContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -514,7 +514,7 @@ fun OtherEntryCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onOtherContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }
@@ -540,7 +540,7 @@ private fun BristolIndicator(type: Int) {
 @Composable
 private fun getBristolColor(type: Int) = when (type) {
     1, 2 -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-    3, 4 -> MaterialTheme.colorScheme.tertiary
+    3, 4 -> MaterialTheme.colorScheme.secondary
     else -> MaterialTheme.colorScheme.error
 }
 

--- a/app/src/main/java/com/privatehealthjournal/ui/components/MedicationCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/MedicationCard.kt
@@ -52,7 +52,7 @@ fun MedicationCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
         )
     ) {
         Row(
@@ -64,7 +64,7 @@ fun MedicationCard(
             Icon(
                 imageVector = Icons.Default.Medication,
                 contentDescription = "Medication",
-                tint = MaterialTheme.colorScheme.tertiary,
+                tint = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -80,7 +80,7 @@ fun MedicationCard(
                     Text(
                         text = entry.dosage,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
                     )
                 }
 
@@ -89,7 +89,7 @@ fun MedicationCard(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
                     )
                 }
 
@@ -97,7 +97,7 @@ fun MedicationCard(
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.5f)
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -106,7 +106,7 @@ fun MedicationCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -114,7 +114,7 @@ fun MedicationCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
                     )
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/components/SpO2Card.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/SpO2Card.kt
@@ -51,7 +51,7 @@ fun SpO2Card(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -63,7 +63,7 @@ fun SpO2Card(
             Icon(
                 imageVector = Icons.Default.Air,
                 contentDescription = "SpO2",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor(),
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -84,7 +84,7 @@ fun SpO2Card(
                     Text(
                         text = "Pulse: $pulse bpm",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                     )
                 }
                 if (entry.notes.isNotBlank()) {
@@ -92,14 +92,14 @@ fun SpO2Card(
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -108,7 +108,7 @@ fun SpO2Card(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -116,7 +116,7 @@ fun SpO2Card(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }
@@ -128,7 +128,7 @@ fun SpO2Card(
 private fun getSpO2Color(spo2: Int) = when {
     spo2 < 90 -> MaterialTheme.colorScheme.error
     spo2 < 95 -> MaterialTheme.colorScheme.tertiary
-    else -> MaterialTheme.colorScheme.primary
+    else -> com.privatehealthjournal.ui.theme.onBiometricContainerColor()
 }
 
 private fun formatTimestamp(timestamp: Long): String {

--- a/app/src/main/java/com/privatehealthjournal/ui/components/StepCountCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/StepCountCard.kt
@@ -57,7 +57,7 @@ fun StepCountCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -69,7 +69,7 @@ fun StepCountCard(
             Icon(
                 imageVector = Icons.Default.DirectionsWalk,
                 contentDescription = "Steps",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor(),
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -88,21 +88,21 @@ fun StepCountCard(
                     text = NumberFormat.getIntegerInstance(Locale.getDefault()).format(entry.steps),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                 )
                 if (entry.notes.isNotBlank()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatDay(entry.dateEpochDay),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -111,7 +111,7 @@ fun StepCountCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -119,7 +119,7 @@ fun StepCountCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/components/WeightCard.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/components/WeightCard.kt
@@ -52,7 +52,7 @@ fun WeightCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
         )
     ) {
         Row(
@@ -64,7 +64,7 @@ fun WeightCard(
             Icon(
                 imageVector = Icons.Default.MonitorWeight,
                 contentDescription = "Weight",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor(),
                 modifier = Modifier.size(32.dp)
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -83,21 +83,21 @@ fun WeightCard(
                     text = "${formatWeight(entry.weight)} $unitLabel",
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor()
                 )
                 if (entry.notes.isNotBlank()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.7f)
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatTimestamp(entry.timestamp),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    color = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.5f)
                 )
             }
             Column {
@@ -106,7 +106,7 @@ fun WeightCard(
                         Icon(
                             imageVector = Icons.Default.Edit,
                             contentDescription = "Edit",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                         )
                     }
                 }
@@ -114,7 +114,7 @@ fun WeightCard(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        tint = com.privatehealthjournal.ui.theme.onBiometricContainerColor().copy(alpha = 0.6f)
                     )
                 }
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodGlucoseScreen.kt
@@ -85,7 +85,8 @@ fun AddBloodGlucoseScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Blood Glucose" else "Log Blood Glucose",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBloodPressureScreen.kt
@@ -77,7 +77,8 @@ fun AddBloodPressureScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Blood Pressure" else "Log Blood Pressure",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddBowelMovementScreen.kt
@@ -80,7 +80,7 @@ fun AddBowelMovementScreen(
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Bowel Movement" else "Log Bowel Movement",
                 onBack = handleBack,
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                containerColor = com.privatehealthjournal.ui.theme.otherContainerColor()
             )
         }
     ) { paddingValues ->
@@ -159,7 +159,7 @@ fun AddBowelMovementScreen(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
+                    containerColor = com.privatehealthjournal.ui.theme.otherAccentColor()
                 )
             ) {
                 Text(if (isEditMode) "Update Entry" else "Save Entry")
@@ -269,8 +269,8 @@ private fun BristolTypeCard(
 private fun getBristolTypeColor(type: Int): Color {
     return when (type) {
         1, 2 -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-        3, 4 -> Color(0xFF4CAF50)
-        5 -> Color(0xFFFFC107)
+        3, 4 -> MaterialTheme.colorScheme.secondary
+        5 -> MaterialTheme.colorScheme.error
         6, 7 -> MaterialTheme.colorScheme.error
         else -> MaterialTheme.colorScheme.primary
     }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCholesterolScreen.kt
@@ -79,7 +79,8 @@ fun AddCholesterolScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Cholesterol" else "Log Cholesterol",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddCycleEntryScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -41,7 +41,6 @@ import com.privatehealthjournal.ui.components.EntryTopAppBar
 import com.privatehealthjournal.ui.components.rememberEditingEntry
 import com.privatehealthjournal.viewmodel.LogViewModel
 
-private val CycleRose = Color(0xFFE91E63)
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -79,7 +78,8 @@ fun AddCycleEntryScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Period Entry" else "Log Period",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.cycleContainerColor()
             )
         }
     ) { paddingValues ->
@@ -91,9 +91,9 @@ fun AddCycleEntryScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             Icon(
-                imageVector = Icons.Default.Favorite,
+                imageVector = Icons.Default.WaterDrop,
                 contentDescription = null,
-                tint = CycleRose,
+                tint = com.privatehealthjournal.ui.theme.cycleAccentColor(),
                 modifier = Modifier.padding(bottom = 8.dp)
             )
 
@@ -114,7 +114,7 @@ fun AddCycleEntryScreen(
                         onClick = { selectedFlow = intensity },
                         label = { Text(intensity.displayLabel) },
                         colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = CycleRose,
+                            selectedContainerColor = com.privatehealthjournal.ui.theme.cycleAccentColor(),
                             selectedLabelColor = Color.White
                         )
                     )
@@ -147,8 +147,8 @@ fun AddCycleEntryScreen(
                         },
                         label = { Text(symptom.displayLabel) },
                         colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = CycleRose.copy(alpha = 0.2f),
-                            selectedLabelColor = CycleRose
+                            selectedContainerColor = com.privatehealthjournal.ui.theme.cycleAccentColor().copy(alpha = 0.2f),
+                            selectedLabelColor = com.privatehealthjournal.ui.theme.cycleAccentColor()
                         )
                     )
                 }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationScreen.kt
@@ -79,7 +79,7 @@ fun AddMedicationScreen(
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Medication" else "Log Medication",
                 onBack = handleBack,
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
             )
         }
     ) { paddingValues ->
@@ -93,7 +93,7 @@ fun AddMedicationScreen(
             Icon(
                 imageVector = Icons.Default.Medication,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.tertiary,
+                tint = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
@@ -221,7 +221,7 @@ fun AddMedicationScreen(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = name.isNotBlank(),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
+                    containerColor = MaterialTheme.colorScheme.secondary
                 )
             ) {
                 Text(if (isEditMode) "Update Medication" else "Save Medication")

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddMedicationSetScreen.kt
@@ -91,7 +91,7 @@ fun AddMedicationSetScreen(
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Medication Set" else "New Medication Set",
                 onBack = handleBack,
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
             )
         }
     ) { paddingValues ->
@@ -105,7 +105,7 @@ fun AddMedicationSetScreen(
             Icon(
                 imageVector = Icons.Default.Medication,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.tertiary,
+                tint = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
@@ -244,7 +244,7 @@ fun AddMedicationSetScreen(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = setName.isNotBlank() && hasValidItems,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
+                    containerColor = MaterialTheme.colorScheme.secondary
                 )
             ) {
                 Text(if (isEditMode) "Update Medication Set" else "Save Medication Set")

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddOtherEntryScreen.kt
@@ -116,7 +116,7 @@ fun AddOtherEntryScreen(
             EntryTopAppBar(
                 title = screenTitle,
                 onBack = handleBack,
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                containerColor = com.privatehealthjournal.ui.theme.otherContainerColor()
             )
         }
     ) { paddingValues ->
@@ -341,7 +341,7 @@ fun AddOtherEntryScreen(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
+                    containerColor = com.privatehealthjournal.ui.theme.otherAccentColor()
                 )
             ) {
                 Text(if (isEditMode) "Update Entry" else "Save Entry")
@@ -480,8 +480,8 @@ private fun BristolTypeCard(
 private fun getBristolTypeColor(type: Int): Color {
     return when (type) {
         1, 2 -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-        3, 4 -> Color(0xFF4CAF50)
-        5 -> Color(0xFFFFC107)
+        3, 4 -> MaterialTheme.colorScheme.secondary
+        5 -> MaterialTheme.colorScheme.error
         6, 7 -> MaterialTheme.colorScheme.error
         else -> MaterialTheme.colorScheme.primary
     }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSpO2Screen.kt
@@ -73,7 +73,8 @@ fun AddSpO2Screen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit SpO2" else "Log SpO2",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddStepCountScreen.kt
@@ -87,7 +87,8 @@ fun AddStepCountScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Steps" else "Log Steps",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddSymptomScreen.kt
@@ -93,7 +93,7 @@ fun AddSymptomScreen(
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Symptom" else "Log Symptom",
                 onBack = handleBack,
-                containerColor = MaterialTheme.colorScheme.secondaryContainer
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
             )
         }
     ) { paddingValues ->
@@ -107,7 +107,7 @@ fun AddSymptomScreen(
             Icon(
                 imageVector = Icons.Default.Warning,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.secondary,
+                tint = MaterialTheme.colorScheme.tertiary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
@@ -172,8 +172,11 @@ fun AddSymptomScreen(
                 steps = 3,
                 modifier = Modifier.fillMaxWidth(),
                 colors = SliderDefaults.colors(
-                    thumbColor = MaterialTheme.colorScheme.secondary,
-                    activeTrackColor = MaterialTheme.colorScheme.secondary
+                    thumbColor = MaterialTheme.colorScheme.tertiary,
+                    activeTrackColor = MaterialTheme.colorScheme.tertiary,
+                    activeTickColor = MaterialTheme.colorScheme.onTertiary,
+                    inactiveTrackColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    inactiveTickColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.5f)
                 )
             )
 
@@ -264,7 +267,7 @@ fun AddSymptomScreen(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = symptomName.isNotBlank(),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondary
+                    containerColor = MaterialTheme.colorScheme.tertiary
                 )
             ) {
                 Text(if (isEditMode) "Update Symptom" else "Save Symptom Entry")

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/AddWeightScreen.kt
@@ -79,7 +79,8 @@ fun AddWeightScreen(
         topBar = {
             EntryTopAppBar(
                 title = if (isEditMode) "Edit Weight" else "Log Weight",
-                onBack = handleBack
+                onBack = handleBack,
+                containerColor = com.privatehealthjournal.ui.theme.biometricContainerColor()
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CalendarScreen.kt
@@ -476,7 +476,7 @@ private fun CalendarDayCell(
                         .clip(CircleShape)
                         .background(
                             if (isSelected) MaterialTheme.colorScheme.onPrimary
-                            else Color(0xFFE91E63)
+                            else com.privatehealthjournal.ui.theme.cycleAccentColor()
                         )
                 )
             }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/CycleTrackingScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -48,7 +48,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-private val CycleRose = Color(0xFFE91E63)
 
 data class PeriodGroup(
     val entries: List<CycleEntry>,
@@ -136,14 +135,14 @@ fun CycleTrackingScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                    containerColor = com.privatehealthjournal.ui.theme.cycleContainerColor()
                 )
             )
         },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddEntry,
-                containerColor = CycleRose,
+                containerColor = com.privatehealthjournal.ui.theme.cycleAccentColor(),
                 contentColor = Color.White
             ) {
                 Icon(imageVector = Icons.Default.Add, contentDescription = "Log Period")
@@ -160,9 +159,9 @@ fun CycleTrackingScreen(
                 verticalArrangement = Arrangement.Center
             ) {
                 Icon(
-                    imageVector = Icons.Default.Favorite,
+                    imageVector = Icons.Default.WaterDrop,
                     contentDescription = null,
-                    tint = CycleRose.copy(alpha = 0.4f),
+                    tint = com.privatehealthjournal.ui.theme.cycleAccentColor().copy(alpha = 0.4f),
                     modifier = Modifier.padding(8.dp)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
@@ -198,7 +197,7 @@ fun CycleTrackingScreen(
                                 text = "Cycle Summary",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
-                                color = CycleRose
+                                color = com.privatehealthjournal.ui.theme.cycleAccentColor()
                             )
                             Spacer(modifier = Modifier.height(12.dp))
                             val lastPeriod = periods.firstOrNull()
@@ -307,7 +306,7 @@ private fun PeriodCard(
             Text(
                 text = period.dominantFlow.displayLabel + " flow",
                 style = MaterialTheme.typography.bodyMedium,
-                color = CycleRose
+                color = com.privatehealthjournal.ui.theme.cycleAccentColor()
             )
             if (period.allSymptoms.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(6.dp))
@@ -317,7 +316,7 @@ private fun PeriodCard(
                             onClick = {},
                             label = { Text(symptom.displayLabel, style = MaterialTheme.typography.labelSmall) },
                             colors = SuggestionChipDefaults.suggestionChipColors(
-                                containerColor = CycleRose.copy(alpha = 0.12f)
+                                containerColor = com.privatehealthjournal.ui.theme.cycleAccentColor().copy(alpha = 0.12f)
                             )
                         )
                     }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/HomeScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.DirectionsWalk
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.MonitorHeart
@@ -180,7 +180,7 @@ fun HomeScreen(
                 Button(
                     onClick = { onNavigate(NavIntent.AddSymptom()) },
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.secondary
+                        containerColor = MaterialTheme.colorScheme.tertiary
                     )
                 ) {
                     Icon(
@@ -197,7 +197,7 @@ fun HomeScreen(
                     Button(
                         onClick = { medsMenuExpanded = true },
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.tertiary
+                            containerColor = MaterialTheme.colorScheme.secondary
                         )
                     ) {
                         Icon(
@@ -239,7 +239,7 @@ fun HomeScreen(
                     Button(
                         onClick = { biometricsMenuExpanded = true },
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+                            containerColor = com.privatehealthjournal.ui.theme.biometricAccentColor()
                         )
                     ) {
                         Icon(
@@ -325,7 +325,7 @@ fun HomeScreen(
                     Button(
                         onClick = { otherMenuExpanded = true },
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.outline
+                            containerColor = com.privatehealthjournal.ui.theme.otherAccentColor()
                         )
                     ) {
                         Icon(
@@ -402,11 +402,11 @@ fun HomeScreen(
                     Button(
                         onClick = { onNavigate(NavIntent.CycleTracking) },
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFFE91E63)
+                            containerColor = com.privatehealthjournal.ui.theme.cycleAccentColor()
                         )
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Favorite,
+                            imageVector = Icons.Default.WaterDrop,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp)
                         )

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MealBudgetScreen.kt
@@ -557,7 +557,7 @@ private fun DayRow(
                                 text = "−$dayStepCredits pts",
                                 style = MaterialTheme.typography.bodySmall,
                                 fontWeight = FontWeight.Medium,
-                                color = Color(0xFF4CAF50)
+                                color = MaterialTheme.colorScheme.secondary
                             )
                         }
                     }
@@ -606,7 +606,7 @@ private fun DayRow(
                                 text = if (exercise.pointCredit != null) "−${exercise.pointCredit} pts" else "—",
                                 style = MaterialTheme.typography.bodySmall,
                                 fontWeight = FontWeight.Medium,
-                                color = if (exercise.pointCredit != null) Color(0xFF4CAF50)
+                                color = if (exercise.pointCredit != null) MaterialTheme.colorScheme.secondary
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                             )
                         }

--- a/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/screens/MedicationSetsScreen.kt
@@ -88,14 +88,14 @@ fun MedicationSetsScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer
                 )
             )
         },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddSet,
-                containerColor = MaterialTheme.colorScheme.tertiary
+                containerColor = MaterialTheme.colorScheme.secondary
             ) {
                 Icon(Icons.Default.Add, contentDescription = "Add Medication Set")
             }
@@ -186,7 +186,7 @@ private fun MedicationSetCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
         )
     ) {
         Column(
@@ -201,7 +201,7 @@ private fun MedicationSetCard(
                 Icon(
                     imageVector = Icons.Default.Medication,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.tertiary,
+                    tint = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.size(28.dp)
                 )
                 Spacer(modifier = Modifier.width(12.dp))
@@ -286,7 +286,7 @@ private fun MedicationSetCard(
                 onClick = onLogAll,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary
+                    containerColor = MaterialTheme.colorScheme.secondary
                 )
             ) {
                 Icon(

--- a/app/src/main/java/com/privatehealthjournal/ui/theme/Theme.kt
+++ b/app/src/main/java/com/privatehealthjournal/ui/theme/Theme.kt
@@ -16,17 +16,75 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
+val BiometricOrangeLight = Color(0xFFFFE0CC)
+val BiometricOrangeMed = Color(0xFFE89048)
+val BiometricOrangeDark = Color(0xFF8A4214)
+val BiometricOrangeContainerDark = Color(0xFF4A2810)
+val BiometricOrangeAccentDark = Color(0xFFFFB07A)
+
+@Composable
+fun biometricContainerColor(): Color =
+    if (isSystemInDarkTheme()) BiometricOrangeContainerDark else BiometricOrangeLight
+
+@Composable
+fun onBiometricContainerColor(): Color =
+    if (isSystemInDarkTheme()) BiometricOrangeLight else BiometricOrangeDark
+
+@Composable
+fun biometricAccentColor(): Color =
+    if (isSystemInDarkTheme()) BiometricOrangeAccentDark else BiometricOrangeMed
+
+val CycleMaroonLight = Color(0xFFF5D5DA)
+val CycleMaroonAccent = Color(0xFF7A2230)
+val CycleMaroonDark = Color(0xFF4D0F1A)
+val CycleMaroonContainerDark = Color(0xFF3D101A)
+val CycleMaroonAccentDark = Color(0xFFD88898)
+
+@Composable
+fun cycleContainerColor(): Color =
+    if (isSystemInDarkTheme()) CycleMaroonContainerDark else CycleMaroonLight
+
+@Composable
+fun onCycleContainerColor(): Color =
+    if (isSystemInDarkTheme()) CycleMaroonLight else CycleMaroonDark
+
+@Composable
+fun cycleAccentColor(): Color =
+    if (isSystemInDarkTheme()) CycleMaroonAccentDark else CycleMaroonAccent
+
+val OtherGreyLight = Color(0xFFE8E8E8)
+val OtherGreyAccent = Color(0xFF6B6B6B)
+val OtherGreyDark = Color(0xFF3A3A3A)
+val OtherGreyContainerDark = Color(0xFF2A2A2A)
+val OtherGreyAccentDark = Color(0xFFA0A0A0)
+
+@Composable
+fun otherContainerColor(): Color =
+    if (isSystemInDarkTheme()) OtherGreyContainerDark else OtherGreyLight
+
+@Composable
+fun onOtherContainerColor(): Color =
+    if (isSystemInDarkTheme()) OtherGreyLight else OtherGreyDark
+
+@Composable
+fun otherAccentColor(): Color =
+    if (isSystemInDarkTheme()) OtherGreyAccentDark else OtherGreyAccent
+
 private val LightColorScheme = lightColorScheme(
-    primary = Color(0xFF4CAF50),
+    primary = Color(0xFF5FA0D2),
     onPrimary = Color.White,
-    primaryContainer = Color(0xFFC8E6C9),
-    onPrimaryContainer = Color(0xFF1B5E20),
-    secondary = Color(0xFFFF7043),
+    primaryContainer = Color(0xFFDCEDF5),
+    onPrimaryContainer = Color(0xFF1F4666),
+    secondary = Color(0xFF4A9938),
     onSecondary = Color.White,
-    secondaryContainer = Color(0xFFFFCCBC),
-    onSecondaryContainer = Color(0xFFBF360C),
-    tertiary = Color(0xFF03A9F4),
+    secondaryContainer = Color(0xFFDDEBCE),
+    onSecondaryContainer = Color(0xFF1F4612),
+    tertiary = Color(0xFFD55050),
     onTertiary = Color.White,
+    tertiaryContainer = Color(0xFFF8D7D6),
+    onTertiaryContainer = Color(0xFF6E1622),
+    error = Color(0xFFA82238),
+    onError = Color.White,
     background = Color(0xFFFFFBFE),
     onBackground = Color(0xFF1C1B1F),
     surface = Color(0xFFFFFBFE),
@@ -34,16 +92,20 @@ private val LightColorScheme = lightColorScheme(
 )
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Color(0xFF81C784),
-    onPrimary = Color(0xFF1B5E20),
-    primaryContainer = Color(0xFF2E7D32),
-    onPrimaryContainer = Color(0xFFC8E6C9),
-    secondary = Color(0xFFFF8A65),
-    onSecondary = Color(0xFFBF360C),
-    secondaryContainer = Color(0xFFD84315),
-    onSecondaryContainer = Color(0xFFFFCCBC),
-    tertiary = Color(0xFF4FC3F7),
-    onTertiary = Color(0xFF01579B),
+    primary = Color(0xFFB6D9EC),
+    onPrimary = Color(0xFF1F4666),
+    primaryContainer = Color(0xFF24445E),
+    onPrimaryContainer = Color(0xFFDCEDF5),
+    secondary = Color(0xFF7DBE58),
+    onSecondary = Color(0xFF1F4612),
+    secondaryContainer = Color(0xFF274E1B),
+    onSecondaryContainer = Color(0xFFDDEBCE),
+    tertiary = Color(0xFFE97A78),
+    onTertiary = Color(0xFF6E1622),
+    tertiaryContainer = Color(0xFF5A1A26),
+    onTertiaryContainer = Color(0xFFF8D7D6),
+    error = Color(0xFFE97A78),
+    onError = Color(0xFF6E1622),
     background = Color(0xFF1C1B1F),
     onBackground = Color(0xFFE6E1E5),
     surface = Color(0xFF1C1B1F),
@@ -53,7 +115,7 @@ private val DarkColorScheme = darkColorScheme(
 @Composable
 fun PrivateHealthJournalTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {


### PR DESCRIPTION
Replace dynamic-color theme with a fixed brand palette so the app's look is consistent across devices and matches the logo work in progress.

Per-category palettes (each light + dark, container/accent/onContainer):
- Meal     blue   (primary slot)
- Symptom  red    (tertiary slot - swapped with Meds)
- Med      green  (secondary slot - swapped with Symptom)
- Biometric orange (custom helpers in Theme.kt)
- Cycle    maroon (custom helpers, droplet icon, desaturated from old pink)
- Other    grey   (custom helpers)

dynamicColor default flipped to false (Theme.kt). Bristol indicator helpers in Add{Bowel,Other}EntryScreen migrated to theme refs; type 3-4 now green ("Normal"), type 5 -> error. MealBudgetScreen exercise credit text uses colorScheme.secondary instead of hardcoded #4CAF50. Symptom slider gets full tertiary palette (active + inactive + ticks).

Add screens (AddSymptom, AddMedication, AddMedicationSet, AddCycle, all biometric Add screens) pass the matching containerColor through EntryTopAppBar so their app bars follow the same category color as their cards. MedicationSetsScreen + CycleTrackingScreen top bars updated to match.